### PR TITLE
improves duplicate detection

### DIFF
--- a/AutoPkgr/LGPopularRepositories.m
+++ b/AutoPkgr/LGPopularRepositories.m
@@ -84,7 +84,8 @@
 {
     NSUInteger match = NSNotFound;
     for (NSString *ws in a) {
-        if ([ws hasSuffix:s]) {
+        NSRange range = [ws rangeOfString:s];
+        if (!NSEqualRanges(range, NSMakeRange(NSNotFound, 0))) {
             match = [a indexOfObject:ws];
             break;
         }


### PR DESCRIPTION
Instead of searching for a suffix of the repo NSString, I look to see
if a substring exists.
Fixes #37
