### PR TITLE
Autosaves defaults when the window is closed

### DIFF
--- a/AutoPkgr/LGConfigurationWindowController.h
+++ b/AutoPkgr/LGConfigurationWindowController.h
@@ -10,7 +10,7 @@
 #import "LGPopularRepositories.h"
 #import "LGApplications.h"
 
-@interface LGConfigurationWindowController : NSWindowController <NSTextDelegate, NSTokenFieldDelegate>
+@interface LGConfigurationWindowController : NSWindowController <NSTextDelegate, NSTokenFieldDelegate, NSWindowDelegate>
 {
     NSUserDefaults *defaults;
 }

--- a/AutoPkgr/LGConfigurationWindowController.m
+++ b/AutoPkgr/LGConfigurationWindowController.m
@@ -779,5 +779,12 @@ static void *XXAuthenticationEnabledContext = &XXAuthenticationEnabledContext;
     [defaults synchronize];
 }
 
+- (BOOL)windowShouldClose:(id)sender
+{
+    [self save];
+    
+    return YES;
+}
+
 
 @end


### PR DESCRIPTION
If a user was editing a field and closed the window without tabbing
out, the value was not guaranteed to be saved.
