### PR TITLE
when building mailcore2, only run for osx architecture with prepare-mac.sh

### DIFF
--- a/mailcore2/build-mac/mailcore2.xcodeproj/project.pbxproj
+++ b/mailcore2/build-mac/mailcore2.xcodeproj/project.pbxproj
@@ -2519,7 +2519,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/../scripts\"\n./prepare.sh\nif test x$? != x0 ; then\n  exit 1\nfi\nfor lib in ctemplate icu4c libetpan ; do\n  rsync -av \"$SRCROOT/../Externals/$lib/lib/\" \"$BUILT_PRODUCTS_DIR\"\ndone\n";
+			shellScript = "cd \"$SRCROOT/../scripts\"\n./prepare-mac.sh\nif test x$? != x0 ; then\n  exit 1\nfi\nfor lib in ctemplate icu4c libetpan ; do\n  rsync -av \"$SRCROOT/../Externals/$lib/lib/\" \"$BUILT_PRODUCTS_DIR\"\ndone\n";
 		};
 		C6BA2B0A1705F4E6003F0E9E /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
I was having issues building from source, it was really slow and my fan was spinning out like crazy, until I changed this in mailcore2's build setting.
