### PR TITLE
catch situations where nil would cause array index exceptions

### DIFF
--- a/AutoPkgr/LGGitHubJSONLoader.m
+++ b/AutoPkgr/LGGitHubJSONLoader.m
@@ -29,6 +29,7 @@
 
     if (error) {
         NSLog(@"NSURLConnection error when attempting to get the latest AutoPkg releases from the GitHub API. Error: %@.", error);
+        return nil;
     }
 
     // Create an array from the JSON data
@@ -36,6 +37,7 @@
 
     if (error) {
         NSLog(@"NSJSONSerialization error when attempting to serialize JSON data from the GitHub API: Error: %@.", error);
+        return nil;
     }
     
     return releases;

--- a/AutoPkgr/LGVersionComparator.m
+++ b/AutoPkgr/LGVersionComparator.m
@@ -14,20 +14,21 @@ static int maximumValuesInVersion = 4;
 
 - (BOOL)isVersion:(NSString *)a greaterThanVersion:(NSString *)b
 {
-    NSArray *versionA = [a componentsSeparatedByString:@"."];
-    versionA = [self normalizeVersionFromArray:versionA];
+    // make sure neither a or b are nil
+    if (a && b){
+        NSArray *versionA = [a componentsSeparatedByString:@"."];
+        versionA = [self normalizeVersionFromArray:versionA];
 
-    NSArray *versionB = [b componentsSeparatedByString:@"."];
-    versionB = [self normalizeVersionFromArray:versionB];
-
-    for (NSInteger i=0; i < maximumValuesInVersion; i++) {
-        if ([[versionA objectAtIndex:i] integerValue] > [[versionB objectAtIndex:i] integerValue]) {
-            return YES;
-        } else if ([[versionA objectAtIndex:i] integerValue] < [[versionB objectAtIndex:i] integerValue]) {
-            return NO;
+        NSArray *versionB = [b componentsSeparatedByString:@"."];
+        versionB = [self normalizeVersionFromArray:versionB];
+        for (NSInteger i=0; i < maximumValuesInVersion; i++) {
+            if ([[versionA objectAtIndex:i] integerValue] > [[versionB objectAtIndex:i] integerValue]) {
+                return YES;
+            } else if ([[versionA objectAtIndex:i] integerValue] < [[versionB objectAtIndex:i] integerValue]) {
+                return NO;
+            }
         }
     }
-
     return NO;
 }
 


### PR DESCRIPTION
If there is no internet connection, the JSON data returned is nil, which will raise exceptions when passed along to the array[i].  In the version it will just return NO, if nil is passed in and with the JSON loader it return nil on error.
