### PR TITLE
fixed incorrect return values, relating to previous change

### DIFF
--- a/AutoPkgr/LGAutoPkgRunner.m
+++ b/AutoPkgr/LGAutoPkgRunner.m
@@ -125,7 +125,7 @@
     autoPkgRepoAddTask.terminationHandler = ^(NSTask *aTask) {
         NSError *error;
         NSDictionary *userInfo;
-        if ([LGError errorWithTaskError:aTask verb:kLGAutoPkgrRepoAdd error:&error]) {
+        if (![LGError errorWithTaskError:aTask verb:kLGAutoPkgrRepoAdd error:&error]) {
             userInfo = @{kNotificationUserInfoError:error};
         }
         [[NSNotificationCenter defaultCenter]postNotificationName:kProgressStopNotification
@@ -161,7 +161,7 @@
     autoPkgRepoRemoveTask.terminationHandler = ^(NSTask *aTask) {
         NSError *error;
         NSDictionary *userInfo;
-        if ([LGError errorWithTaskError:aTask verb:kLGAutoPkgrRepoDelete error:&error]) {
+        if (![LGError errorWithTaskError:aTask verb:kLGAutoPkgrRepoDelete error:&error]) {
             userInfo = @{kNotificationUserInfoError:error};
         }
         [[NSNotificationCenter defaultCenter]postNotificationName:kProgressStopNotification
@@ -192,7 +192,7 @@
     updateAutoPkgReposTask.terminationHandler = ^(NSTask *aTask) {
         NSDictionary *userInfo;
         NSError *error;
-        if ([LGError errorWithTaskError:aTask verb:kLGAutoPkgrRepoUpdate error:&error]) {
+        if (![LGError errorWithTaskError:aTask verb:kLGAutoPkgrRepoUpdate error:&error]) {
             userInfo = @{kNotificationUserInfoError:error};
         }
 
@@ -219,7 +219,7 @@
     autoPkgRunTask.terminationHandler = ^(NSTask *aTask) {
         NSDictionary *userInfo = nil;
         NSError *error;
-        if ([LGError errorWithTaskError:aTask verb:kLGAutoPkgrRun error:&error]) {
+        if (![LGError errorWithTaskError:aTask verb:kLGAutoPkgrRun error:&error]) {
             userInfo = @{kNotificationUserInfoError:error};
         }
         [[NSNotificationCenter defaultCenter]postNotificationName:kRunAutoPkgCompleteNotification

--- a/AutoPkgr/LGError.m
+++ b/AutoPkgr/LGError.m
@@ -131,7 +131,7 @@ static NSString *errorMessageFromAutoPkgVerb(LGAutoPkgrVerb verb)
         *error = taskError;
     }
     // if we have a Task error return YES if the taskError codes is 0, otherwise NO
-    return taskError ? taskError.code == kLGErrorSuccess : NO;
+    return taskError ? taskError.code == kLGErrorSuccess : YES;
 }
 
 + (NSError *)errorWithTaskError:(NSTask *)task verb:(LGAutoPkgrVerb)verb


### PR DESCRIPTION
previous devel commit  0161dfbfde71e6dd29841145d1506b6345be2fc1 reversed the logic, this catches places where it was LGError class was used,  but not changed in accordingly.
