### PR TITLE
Correct LGError comments

### DIFF
--- a/AutoPkgr/LGError.h
+++ b/AutoPkgr/LGError.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSInteger, LGAutoPkgrVerb) {
  *  @param code  cooresponging LGErrorCodes
  *  @param error __autoreleasing NSError object
  *
- *  @return YES if Error has occured, NO if error.code = kLGErrorSuccess.
+ *  @return NO if error occured and error.code is not 0, otherwise YES
  */
 + (BOOL)errorWithCode:(LGErrorCodes)code error:(NSError **)error;
 /**
@@ -76,8 +76,8 @@ typedef NS_ENUM(NSInteger, LGAutoPkgrVerb) {
  *  @param verb  Cooresponding Action Word Describing the AutoPkgr task process
  *  @param error __autoreleasing NSError object
  *
- *  @return YES if Error has occured, NO if error.code = kLGErrorSuccess.
- *  @discussion If the task is not complete the error will return NO;
+ *  @return NO if error occured and the exit code is not 0, otherwise YES
+ *  @discussion If the task is not complete this will return YES;
  */
 + (BOOL)errorWithTaskError:(NSTask *)task verb:(LGAutoPkgrVerb)verb error:(NSError **)error;
 /**

--- a/AutoPkgr/LGError.m
+++ b/AutoPkgr/LGError.m
@@ -130,7 +130,7 @@ static NSString *errorMessageFromAutoPkgVerb(LGAutoPkgrVerb verb)
     if (error && taskError) {
         *error = taskError;
     }
-    // if we have a Task error return YES if the taskError codes is 0, otherwise NO
+    // If no error object was created, or the error code is 0 return YES, otherwise NO.
     return taskError ? taskError.code == kLGErrorSuccess : YES;
 }
 


### PR DESCRIPTION
The comment strings did not correctly represent the return values.  This makes them right.
