### PR TITLE
fix issue #135 and #136 

### DIFF
--- a/AutoPkgr/LGEmailer.m
+++ b/AutoPkgr/LGEmailer.m
@@ -76,9 +76,11 @@
             }
         }
         
+        NSString *from = defaults.SMTPFrom ? defaults.SMTPFrom :@"AutoPkgr";
+        
         MCOMessageBuilder * builder = [[MCOMessageBuilder alloc] init];
         [[builder header] setFrom:[MCOAddress addressWithDisplayName:@"AutoPkgr Notification"
-                                                             mailbox:defaults.SMTPFrom ? defaults.SMTPFrom:@""]];
+                                                             mailbox:from]];
         
         NSMutableArray *to = [[NSMutableArray alloc] init];
         for (NSString *toAddress in defaults.SMTPTo) {
@@ -87,7 +89,9 @@
                 [to addObject:newAddress];
             }
         }
-        NSString *fullSubject = [NSString stringWithFormat:@"%@ on %@",subject,[[NSHost currentHost] name]];
+
+        NSString *fullSubject = [NSString stringWithFormat:@"%@ on %@",subject,[[NSHost currentHost] localizedName]];
+        
         [[builder header] setTo:to];
         [[builder header] setSubject:fullSubject];
         [builder setHTMLBody:message];
@@ -100,10 +104,10 @@
                                                                                             kLGNotificationUserInfoMessage:message}];
             
             if (error) {
-                NSLog(@"Error sending email from %@: %@", smtpSession.username, error);
+                NSLog(@"Error sending email from %@: %@", from, error);
                 [userInfo setObject:error forKey:kLGNotificationUserInfoError];
             } else {
-                NSLog(@"Successfully sent email from %@.", smtpSession.username);
+                NSLog(@"Successfully sent email from %@.", from);
             }
             
             [center postNotificationName:kLGNotificationEmailSent


### PR DESCRIPTION
Sets hostname in subject to use the localized name 

``` Objective-C
[[NSHost currentHost] localizedName]]
```

(this should be the equivalent to the computer name is sharing preferences);

And uses NSUserDefaults SMTPFrom in sent email log message
