### PR TITLE
Fixes #149

### DIFF
--- a/AutoPkgr/LGAutoPkgTask.h
+++ b/AutoPkgr/LGAutoPkgTask.h
@@ -199,11 +199,18 @@ extern NSString *const kLGAutoPkgRepoPathKey;
 + (void)repoUpdate:(void (^)(NSError *error))reply;
 
 /**
- *  Equivelant to /usr/bin/local/autopkg repo-list
+ *  Equivelant to /usr/bin/local/autopkg repo-list (Asynchronous)
  *
  *  @param reply  The block to be executed on upon task completion. This block has no return value and takes two arguments: NSArray, NSError
  */
 + (void)repoList:(void (^)(NSArray *repos, NSError *error))reply;
+
+/**
+ *  Equivelant to /usr/bin/local/autopkg repo-list (Synchronous)
+ *
+ *  @return list of installed autopkg repos
+ */
++ (NSArray *)repoList;
 
 #pragma mark-- Other
 /**

--- a/AutoPkgr/LGAutoPkgTask.m
+++ b/AutoPkgr/LGAutoPkgTask.m
@@ -479,6 +479,19 @@ NSString *autopkg()
     }];
 }
 
++(NSArray *)repoList
+{
+    LGAutoPkgTask *task = [[LGAutoPkgTask alloc] init];
+    task.arguments = @[ @"repo-list" ];
+    if ([task launch:nil]) {
+        id results = [task results];
+        if ([results isKindOfClass:[NSArray class]]) {
+            return results;
+        }
+    }
+    return nil;
+}
+
 #pragma mark-- Other Methods
 + (NSString *)version
 {

--- a/AutoPkgr/LGPopularRepositories.m
+++ b/AutoPkgr/LGPopularRepositories.m
@@ -131,20 +131,19 @@
 
 - (void)getAndParseLocalAutoPkgRecipeRepos // Strips out the local path of the cloned git repository and returns an array with only the URLs
 {
-    [LGAutoPkgTask repoList:^(NSArray *repos, NSError *error) {
-        NSMutableArray *strippedRepos = [[NSMutableArray alloc] init];
-        
-        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\((https?://.+)\\)" options:0 error:&error];
-        
-        for (NSString *repo in repos) {
-            NSTextCheckingResult *result = [regex firstMatchInString:repo options:0 range:NSMakeRange(0,[repo length])];
-            if ([result numberOfRanges] == 2) {
-                [strippedRepos addObject:[repo substringWithRange:[result rangeAtIndex:1]]];
-            }
+    NSError *error;
+    
+    NSMutableArray *strippedRepos = [[NSMutableArray alloc] init];
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\((https?://.+)\\)" options:0 error:&error];
+    
+    for (NSString *repo in [LGAutoPkgTask repoList]) {
+        NSTextCheckingResult *result = [regex firstMatchInString:repo options:0 range:NSMakeRange(0,[repo length])];
+        if ([result numberOfRanges] == 2) {
+            [strippedRepos addObject:[repo substringWithRange:[result rangeAtIndex:1]]];
         }
-        
-        _activeRepos =  [NSArray arrayWithArray:strippedRepos];
-    }];
+    }
+    
+    _activeRepos =  [NSArray arrayWithArray:strippedRepos];
 }
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView


### PR DESCRIPTION
@homebysix this should take care of the repo not showing up or appearing between launches part of #149.  The LGAutoPkgTask was using blocks to set an array which arrived too late to the party.   Now it's a synchronous call that should eliminate that particular problem.   I'm not sure about your repo not showing up, @futureimperfect may want to take a look into that.
