### PR TITLE
Use system proxy & update read me

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,7 @@ pod 'Sparkle', '~> 1.8'
 pod 'SSKeychain', '~> 1.2'
 pod 'AFNetworking', '~> 2.4.1'
 pod 'XMLDictionary', '~> 1.4'
+pod 'AHProxySettings'
 end
 
 target "AutoPkgrTests" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,18 +17,21 @@ PODS:
   - AFNetworking/Reachability (2.4.1)
   - AFNetworking/Security (2.4.1)
   - AFNetworking/Serialization (2.4.1)
+  - AHProxySettings (0.1)
   - Sparkle (1.8.0)
   - SSKeychain (1.2.2)
   - XMLDictionary (1.4)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.4.1)
+  - AHProxySettings
   - Sparkle (~> 1.8)
   - SSKeychain (~> 1.2)
   - XMLDictionary (~> 1.4)
 
 SPEC CHECKSUMS:
   AFNetworking: 0aabc6fae66d6e5d039eeb21c315843c7aae51ab
+  AHProxySettings: c2c5a19614bd74d0aaa2ff0529330236cb54d2c3
   Sparkle: 5eb20bb37ca21e471dab8417dee880198d905327
   SSKeychain: cc48bd3ad24fcd9125adb9e0d23dd50b8bbd08b9
   XMLDictionary: 735e81b9a043e220b0d24e9d4f16719606f2e0fc

--- a/README.md
+++ b/README.md
@@ -118,13 +118,38 @@ For detailed tips on integrating AutoPkgr with Casper, and to see some descripti
 Using a Proxy
 -------------
 
-If your network uses a proxy, you may need to run one or more of these commands to configure AutoPkg/AutoPkgr to use your proxy for internet access. Running these commands is equivalent to this shell command: `export HTTP_PROXY=http://proxy:8080`
+If your network uses a proxy, you may need to run one or more of these commands to configure AutoPkg/AutoPkgr to use your proxy for internet access.
+
+Note: Running these commands is equivalent to this shell command:
+```export HTTP_PROXY=http://proxy:8080```  
+It should not be compared to what you can access from a web browser.  If running autopkg in the shell won't work with the environmental variables set, neither will AutoPkgr.
+ 
+Note: Proxy support is still in early development and we would love feedback from the community as to it's functioning, both success and failure.
+
+
+1. Use proxies defined in System Preferences. 
+`defaults write com.lindegroup.AutoPkgr useSystemProxies -bool true`  
+
+	This should also pick up auto-detected WPAD/PAC proxies. Make sure you have the domains that should not use a proxy listed in the 
+`System Preferences -> Network -> Advanced -> Proxies -> "Bypass proxy settings for these Hosts & Domains"`
+ 
+2. If using the settings from system preferences doesn't work you can try to manually set the proxy environment yourself.
+
+	Note: when manually setting make sure to unset useSystemProxies `defaults write com.lindegroup.AutoPkgr useSystemProxies -bool false` 
 
 - To use HTTP proxy: `defaults write com.lindegroup.AutoPkgr HTTP_PROXY http://proxy:8080`
+
 - To use HTTPS proxy: `defaults write com.lindegroup.AutoPkgr HTTPS_PROXY https://proxy:8080`
+
 - To use HTTP proxy with authentication: `defaults write com.lindegroup.AutoPkgr HTTP_PROXY http://username:password@proxy:8080`
+
 - To use HTTPS proxy with authentication: `defaults write com.lindegroup.AutoPkgr HTTPS_PROXY https://username:password@proxy:8080`
+
+- To add a list of bypassed hosts: `defaults write com.lindegroup.AutoPkgr NO_PROXY ".local,10.0.0.0/24,.mylocaldomain.com"`
+(this is a list of comma separated items use .xxx.xxx to bypass an entire domain)
+
 - To stop using HTTP proxy: `defaults remove com.lindegroup.AutoPkgr HTTP_PROXY`
+
 - To stop using HTTPS proxy: `defaults remove com.lindegroup.AutoPkgr HTTPS_PROXY`
 
 _Note: This will not create or modify any system proxy settings; it will only add them to your shell env._


### PR DESCRIPTION
@homebysix let's include this in the 1.1.1 release too.
There is a new pod http://cocoadocs.org/docsets/AHProxySettings/0.1/ so you'll need to do `pod update` and will most likely need to clean your build folder.

It really seemed to work where the other methods weren't in #187
It also added the ability to manually set NO_PROXY so that's an improvement too.

Let me know if you have any questions.
