### PR TITLE
Explicitly set JSSVerifySSL during each phase of certificate trust challenge.

### DIFF
--- a/AutoPkgr/LGTestPort.m
+++ b/AutoPkgr/LGTestPort.m
@@ -106,6 +106,13 @@
     // Set up the operation
     AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
 
+    // Since this is just a server test, we don't care about certificate validation here
+    // so set up a policy that will ignore certificate trust issues.
+    AFSecurityPolicy *policy = [[AFSecurityPolicy alloc] init];
+    policy.allowInvalidCertificates = YES;
+    policy.validatesCertificateChain = NO;
+
+    operation.securityPolicy = policy;
     [operation setRedirectResponseBlock:^NSURLRequest * (NSURLConnection * connection, NSURLRequest * request, NSURLResponse * redirectResponse) {
         NSLog(@"redirected %@",redirectResponse);
         redirectedURL = [(NSHTTPURLResponse *)redirectResponse allHeaderFields][@"Location"];


### PR DESCRIPTION
There are a few fringe conditions that result in caching the certificate trust challenge results, but still resetting the JSS_VERIFY_SSL to YES causing python-jss to fail when accessing server with self signed certificates.

Also during server reachability test accept all certificate trust challenges, so it will not result in a status code > 400.
