### PR TITLE
Consistency between 10.9 and 10.10 rendering.

### DIFF
--- a/AutoPkgr.xcodeproj/project.pbxproj
+++ b/AutoPkgr.xcodeproj/project.pbxproj
@@ -1,959 +1,2726 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>04CA360328E704A8E80B244B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-AutoPkgr.debug.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-AutoPkgr/Pods-AutoPkgr.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>16E87146BB0135D03CB6ECA8</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-AutoPkgr.release.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-AutoPkgr/Pods-AutoPkgr.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A0A869D195CE5DB00A49434</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.pb-project</string>
+			<key>name</key>
+			<string>mailcore2.xcodeproj</string>
+			<key>path</key>
+			<string>mailcore2/build-mac/mailcore2.xcodeproj</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>1A0A869E195CE5DB00A49434</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1A0A86A6195CE5DC00A49434</string>
+				<string>1A0A86A8195CE5DC00A49434</string>
+				<string>1A0A86AA195CE5DC00A49434</string>
+				<string>1A0A86AC195CE5DC00A49434</string>
+				<string>1A0A86AE195CE5DC00A49434</string>
+				<string>8B8AB7F11A16A26B00B03C00</string>
+				<string>8B8AB7F31A16A26B00B03C00</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A0A86A5195CE5DC00A49434</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>1A0A869D195CE5DB00A49434</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>2</string>
+			<key>remoteGlobalIDString</key>
+			<string>C64EA537169E772200778456</string>
+			<key>remoteInfo</key>
+			<string>static mailcore2 osx</string>
+		</dict>
+		<key>1A0A86A6195CE5DC00A49434</key>
+		<dict>
+			<key>fileType</key>
+			<string>archive.ar</string>
+			<key>isa</key>
+			<string>PBXReferenceProxy</string>
+			<key>path</key>
+			<string>libMailCore.a</string>
+			<key>remoteRef</key>
+			<string>1A0A86A5195CE5DC00A49434</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1A0A86A7195CE5DC00A49434</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>1A0A869D195CE5DB00A49434</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>2</string>
+			<key>remoteGlobalIDString</key>
+			<string>C6BA2C191705F4E6003F0E9E</string>
+			<key>remoteInfo</key>
+			<string>static mailcore2 ios</string>
+		</dict>
+		<key>1A0A86A8195CE5DC00A49434</key>
+		<dict>
+			<key>fileType</key>
+			<string>archive.ar</string>
+			<key>isa</key>
+			<string>PBXReferenceProxy</string>
+			<key>path</key>
+			<string>libMailCore-ios.a</string>
+			<key>remoteRef</key>
+			<string>1A0A86A7195CE5DC00A49434</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1A0A86A9195CE5DC00A49434</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>1A0A869D195CE5DB00A49434</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>2</string>
+			<key>remoteGlobalIDString</key>
+			<string>C64EA78C169F259200778456</string>
+			<key>remoteInfo</key>
+			<string>tests</string>
+		</dict>
+		<key>1A0A86AA195CE5DC00A49434</key>
+		<dict>
+			<key>fileType</key>
+			<string>compiled.mach-o.executable</string>
+			<key>isa</key>
+			<string>PBXReferenceProxy</string>
+			<key>path</key>
+			<string>tests</string>
+			<key>remoteRef</key>
+			<string>1A0A86A9195CE5DC00A49434</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1A0A86AB195CE5DC00A49434</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>1A0A869D195CE5DB00A49434</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>2</string>
+			<key>remoteGlobalIDString</key>
+			<string>C6A81B911706840C00882C15</string>
+			<key>remoteInfo</key>
+			<string>test-ios</string>
+		</dict>
+		<key>1A0A86AC195CE5DC00A49434</key>
+		<dict>
+			<key>fileType</key>
+			<string>wrapper.application</string>
+			<key>isa</key>
+			<string>PBXReferenceProxy</string>
+			<key>path</key>
+			<string>test-ios.app</string>
+			<key>remoteRef</key>
+			<string>1A0A86AB195CE5DC00A49434</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1A0A86AD195CE5DC00A49434</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>1A0A869D195CE5DB00A49434</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>2</string>
+			<key>remoteGlobalIDString</key>
+			<string>C6BD288D170BD71100A91AC1</string>
+			<key>remoteInfo</key>
+			<string>mailcore osx</string>
+		</dict>
+		<key>1A0A86AE195CE5DC00A49434</key>
+		<dict>
+			<key>fileType</key>
+			<string>wrapper.framework</string>
+			<key>isa</key>
+			<string>PBXReferenceProxy</string>
+			<key>path</key>
+			<string>MailCore.framework</string>
+			<key>remoteRef</key>
+			<string>1A0A86AD195CE5DC00A49434</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1A0A86AF195CE63900A49434</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1A0A86AE195CE5DC00A49434</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1A0A86B0195CE69300A49434</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Security.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/Security.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>1A0A86B1195CE69300A49434</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1A0A86B0195CE69300A49434</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1A0A86B2195CE6B500A49434</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>1A0A869D195CE5DB00A49434</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>C6BD288C170BD71100A91AC1</string>
+			<key>remoteInfo</key>
+			<string>mailcore osx</string>
+		</dict>
+		<key>1A0A86B3195CE6B500A49434</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>mailcore osx</string>
+			<key>targetProxy</key>
+			<string>1A0A86B2195CE6B500A49434</string>
+		</dict>
+		<key>1A0A86B4195CE6BF00A49434</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>dstPath</key>
+			<string></string>
+			<key>dstSubfolderSpec</key>
+			<string>10</string>
+			<key>files</key>
+			<array>
+				<string>1A0A86B5195CE6D800A49434</string>
+			</array>
+			<key>isa</key>
+			<string>PBXCopyFilesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>1A0A86B5195CE6D800A49434</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1A0A86AE195CE5DC00A49434</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>CodeSignOnCopy</string>
+				</array>
+			</dict>
+		</dict>
+		<key>1A1BAD94197A0407008192A7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGVersionComparator.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A1BAD95197A0407008192A7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGVersionComparator.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A1BAD96197A0407008192A7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1A1BAD95197A0407008192A7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1A1BAD9C197A4133008192A7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGGitHubJSONLoader.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A1BAD9D197A4133008192A7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGGitHubJSONLoader.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A1BAD9E197A4133008192A7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1A1BAD9D197A4133008192A7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1A2C7FAC19CC9F8300CFF472</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1A2C7FAD19CC9F8300CFF472</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>scripts</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>1A2C7FAD19CC9F8300CFF472</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.python</string>
+			<key>path</key>
+			<string>codesign.py</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A2C7FAE19CC9F8300CFF472</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1A2C7FAD19CC9F8300CFF472</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1A56282C19CC01D600980AB9</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${PROJECT_DIR}/scripts/codesign.py"</string>
+		</dict>
+		<key>1A979FDE1960BCCC00EE9881</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGUnzipper.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A979FDF1960BCCC00EE9881</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGUnzipper.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A979FE01960BCCC00EE9881</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1A979FDF1960BCCC00EE9881</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC69544195B59ED00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC69556195B59ED00D2BD81</string>
+				<string>1AC6954F195B59ED00D2BD81</string>
+				<string>1AC6954E195B59ED00D2BD81</string>
+				<string>1AC69574195B59EE00D2BD81</string>
+				<string>1A0A869D195CE5DB00A49434</string>
+				<string>90C60AB0B9E4D774CB4EA44A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69545195B59ED00D2BD81</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>CLASSPREFIX</key>
+				<string>LG</string>
+				<key>LastUpgradeCheck</key>
+				<string>0600</string>
+				<key>ORGANIZATIONNAME</key>
+				<string>The Linde Group, Inc.</string>
+				<key>TargetAttributes</key>
+				<dict>
+					<key>1AC6956D195B59EE00D2BD81</key>
+					<dict>
+						<key>TestTargetID</key>
+						<string>1AC6954C195B59ED00D2BD81</string>
+					</dict>
+				</dict>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>1AC69548195B59ED00D2BD81</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+				<string>Base</string>
+			</array>
+			<key>mainGroup</key>
+			<string>1AC69544195B59ED00D2BD81</string>
+			<key>productRefGroup</key>
+			<string>1AC6954E195B59ED00D2BD81</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array>
+				<dict>
+					<key>ProductGroup</key>
+					<string>1A0A869E195CE5DB00A49434</string>
+					<key>ProjectRef</key>
+					<string>1A0A869D195CE5DB00A49434</string>
+				</dict>
+			</array>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>1AC6954C195B59ED00D2BD81</string>
+				<string>1AC6956D195B59EE00D2BD81</string>
+			</array>
+		</dict>
+		<key>1AC69548195B59ED00D2BD81</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>1AC6957C195B59EE00D2BD81</string>
+				<string>1AC6957D195B59EE00D2BD81</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>1AC69549195B59ED00D2BD81</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>1AC6955D195B59EE00D2BD81</string>
+				<string>1AC69564195B59EE00D2BD81</string>
+				<string>1AC9841F195CEC360071CAB3</string>
+				<string>1AC9840A195CE7D60071CAB3</string>
+				<string>BE87994B1995BA410082472B</string>
+				<string>1AC86D3D195E0AC6006FDD2B</string>
+				<string>BE025CF619BAE93400D36345</string>
+				<string>BE025CFE19BAEF8800D36345</string>
+				<string>1AC98412195CE8520071CAB3</string>
+				<string>BEAA76CC19BFD635002D73EE</string>
+				<string>6A0ACE34196FB349002C7FE4</string>
+				<string>BE32178B19ED9ACA00A92E5A</string>
+				<string>6A0BABE9196E560000A136BB</string>
+				<string>BE57733819D519E400D872A4</string>
+				<string>BE0E857919D668F600B25B5E</string>
+				<string>1A1BAD9E197A4133008192A7</string>
+				<string>BE32178E19EDA15400A92E5A</string>
+				<string>6A53625D1988BE59008A949C</string>
+				<string>BEFC931D1995F0710074C938</string>
+				<string>1A1BAD96197A0407008192A7</string>
+				<string>1A979FE01960BCCC00EE9881</string>
+				<string>BE73CDC719E062AC00441443</string>
+				<string>BE39FE5319DFBB0100C1B4A1</string>
+				<string>BEE8CF1319E0E7F400981C4B</string>
+				<string>BE77A80019E37C910022B6FB</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>1AC6954A195B59ED00D2BD81</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>BE8526B219D5F641007DFA9E</string>
+				<string>1A0A86B1195CE69300A49434</string>
+				<string>1A0A86AF195CE63900A49434</string>
+				<string>1AC69551195B59ED00D2BD81</string>
+				<string>4B8E6E4F9D8944C883A98423</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>1AC6954B195B59ED00D2BD81</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>1AC98429195DF6DE0071CAB3</string>
+				<string>8BB217F619709A2C00EF8B93</string>
+				<string>1AC6955B195B59ED00D2BD81</string>
+				<string>1AC69569195B59EE00D2BD81</string>
+				<string>1A2C7FAE19CC9F8300CFF472</string>
+				<string>1AC98420195CEC360071CAB3</string>
+				<string>BE57AC2A19BA3BBC00BB17B1</string>
+				<string>1AC98427195DF6350071CAB3</string>
+				<string>1AC69561195B59EE00D2BD81</string>
+				<string>1AC69567195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>1AC6954C195B59ED00D2BD81</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>1AC6957E195B59EE00D2BD81</string>
+			<key>buildPhases</key>
+			<array>
+				<string>570AE652B42D4D4D86875A8A</string>
+				<string>BECFF2B619CA9854004C2721</string>
+				<string>1AC69549195B59ED00D2BD81</string>
+				<string>1AC6954A195B59ED00D2BD81</string>
+				<string>1AC6954B195B59ED00D2BD81</string>
+				<string>1A0A86B4195CE6BF00A49434</string>
+				<string>C97E222596F14727B875BF98</string>
+				<string>1A56282C19CC01D600980AB9</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>1A0A86B3195CE6B500A49434</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>AutoPkgr</string>
+			<key>productName</key>
+			<string>AutoPkgr</string>
+			<key>productReference</key>
+			<string>1AC6954D195B59ED00D2BD81</string>
+			<key>productType</key>
+			<string>com.apple.product-type.application</string>
+		</dict>
+		<key>1AC6954D195B59ED00D2BD81</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.application</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>AutoPkgr.app</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1AC6954E195B59ED00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC6954D195B59ED00D2BD81</string>
+				<string>1AC6956E195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC6954F195B59ED00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BE8526B119D5F641007DFA9E</string>
+				<string>1A0A86B0195CE69300A49434</string>
+				<string>1AC69550195B59ED00D2BD81</string>
+				<string>1AC6956F195B59EE00D2BD81</string>
+				<string>1AC69552195B59ED00D2BD81</string>
+				<string>FF435269A548437DA5380201</string>
+				<string>930ADF1FA6C29018DAE59FD8</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69550195B59ED00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Cocoa.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/Cocoa.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>1AC69551195B59ED00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC69550195B59ED00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC69552195B59ED00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC69553195B59ED00D2BD81</string>
+				<string>1AC69554195B59ED00D2BD81</string>
+				<string>1AC69555195B59ED00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Other Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69553195B59ED00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>AppKit.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/AppKit.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>1AC69554195B59ED00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>CoreData.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/CoreData.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>1AC69555195B59ED00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>1AC69556195B59ED00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC86D36195E0972006FDD2B</string>
+				<string>BE40CB7719D4441600A1DABD</string>
+				<string>BE40CB7819D4444D00A1DABD</string>
+				<string>BE39FE5419DFBB2900C1B4A1</string>
+				<string>1AC9841E195CEC360071CAB3</string>
+				<string>1AC69565195B59EE00D2BD81</string>
+				<string>1AC69568195B59EE00D2BD81</string>
+				<string>1AC98423195DF6270071CAB3</string>
+				<string>1AC69557195B59ED00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>AutoPkgr</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69557195B59ED00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC69558195B59ED00D2BD81</string>
+				<string>1AC69559195B59ED00D2BD81</string>
+				<string>BE57AC2C19BA3BBC00BB17B1</string>
+				<string>1AC6955C195B59ED00D2BD81</string>
+				<string>1AC6955E195B59EE00D2BD81</string>
+				<string>1AC6955F195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69558195B59ED00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>AutoPkgr-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69559195B59ED00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC6955A195B59ED00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC6955A195B59ED00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC6955B195B59ED00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC69559195B59ED00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC6955C195B59ED00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>main.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC6955D195B59EE00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC6955C195B59ED00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC6955E195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AutoPkgr-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC6955F195B59EE00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC69560195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>Credits.rtf</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69560195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.rtf</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/Credits.rtf</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69561195B59EE00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC6955F195B59EE00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC69562195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGAppDelegate.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69563195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGAppDelegate.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69564195B59EE00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC69563195B59EE00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC69565195B59EE00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC69566195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>MainMenu.xib</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69566195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>file.xib</string>
+			<key>name</key>
+			<string>Base</string>
+			<key>path</key>
+			<string>Base.lproj/MainMenu.xib</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69567195B59EE00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC69565195B59EE00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC69568195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>folder.assetcatalog</string>
+			<key>path</key>
+			<string>Images.xcassets</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69569195B59EE00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC69568195B59EE00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC6956A195B59EE00D2BD81</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>BE025CFF19BAEF8800D36345</string>
+				<string>1AC6957B195B59EE00D2BD81</string>
+				<string>BE025CF719BAE93400D36345</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>1AC6956B195B59EE00D2BD81</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>1AC69571195B59EE00D2BD81</string>
+				<string>1AC69570195B59EE00D2BD81</string>
+				<string>95100698DA9F8FE9BF866A34</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>1AC6956C195B59EE00D2BD81</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>1AC69579195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>1AC6956D195B59EE00D2BD81</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>1AC69581195B59EE00D2BD81</string>
+			<key>buildPhases</key>
+			<array>
+				<string>61DD19B85D50CC5311395838</string>
+				<string>1AC6956A195B59EE00D2BD81</string>
+				<string>1AC6956B195B59EE00D2BD81</string>
+				<string>1AC6956C195B59EE00D2BD81</string>
+				<string>75AC16A7785ECD4E7736EE19</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>1AC69573195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>AutoPkgrTests</string>
+			<key>productName</key>
+			<string>AutoPkgrTests</string>
+			<key>productReference</key>
+			<string>1AC6956E195B59EE00D2BD81</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle.unit-test</string>
+		</dict>
+		<key>1AC6956E195B59EE00D2BD81</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>AutoPkgrTests.xctest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1AC6956F195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>XCTest.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/XCTest.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>1AC69570195B59EE00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC6956F195B59EE00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC69571195B59EE00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC69550195B59ED00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC69572195B59EE00D2BD81</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>1AC69545195B59ED00D2BD81</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>1AC6954C195B59ED00D2BD81</string>
+			<key>remoteInfo</key>
+			<string>AutoPkgr</string>
+		</dict>
+		<key>1AC69573195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>target</key>
+			<string>1AC6954C195B59ED00D2BD81</string>
+			<key>targetProxy</key>
+			<string>1AC69572195B59EE00D2BD81</string>
+		</dict>
+		<key>1AC69574195B59EE00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC6957A195B59EE00D2BD81</string>
+				<string>1AC69575195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>AutoPkgrTests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69575195B59EE00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC69576195B59EE00D2BD81</string>
+				<string>1AC69577195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69576195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>AutoPkgrTests-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69577195B59EE00D2BD81</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1AC69578195B59EE00D2BD81</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69578195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC69579195B59EE00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC69577195B59EE00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC6957A195B59EE00D2BD81</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AutoPkgrTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC6957B195B59EE00D2BD81</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC6957A195B59EE00D2BD81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC6957C195B59EE00D2BD81</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
+				<string>YES</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>1AC6957D195B59EE00D2BD81</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
+				<string>YES</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>1AC6957E195B59EE00D2BD81</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>1AC6957F195B59EE00D2BD81</string>
+				<string>1AC69580195B59EE00D2BD81</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>1AC6957F195B59EE00D2BD81</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>04CA360328E704A8E80B244B</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
+				<string>AppIcon</string>
+				<key>CODE_SIGN_IDENTITY</key>
+				<string>Developer ID Application: The Linde Group Computer Support Inc (JVY2ZR6SEF)</string>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AutoPkgr/AutoPkgr-Prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>AutoPkgr/AutoPkgr-Info.plist</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.8</string>
+				<key>OTHER_CODE_SIGN_FLAGS</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>app</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>1AC69580195B59EE00D2BD81</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>16E87146BB0135D03CB6ECA8</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
+				<string>AppIcon</string>
+				<key>CODE_SIGN_IDENTITY</key>
+				<string>Developer ID Application: The Linde Group Computer Support Inc (JVY2ZR6SEF)</string>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AutoPkgr/AutoPkgr-Prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>AutoPkgr/AutoPkgr-Info.plist</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.8</string>
+				<key>OTHER_CODE_SIGN_FLAGS</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>app</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>1AC69581195B59EE00D2BD81</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>1AC69582195B59EE00D2BD81</string>
+				<string>1AC69583195B59EE00D2BD81</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>1AC69582195B59EE00D2BD81</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>349C4BBE0FECE20F0C28E9BE</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>BUNDLE_LOADER</key>
+				<string>$(BUILT_PRODUCTS_DIR)/AutoPkgr.app/Contents/MacOS/AutoPkgr</string>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AutoPkgr/AutoPkgr-Prefix.pch</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>INFOPLIST_FILE</key>
+				<string>AutoPkgrTests/AutoPkgrTests-Info.plist</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>TEST_HOST</key>
+				<string>$(BUNDLE_LOADER)</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>xctest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>1AC69583195B59EE00D2BD81</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>ADA9DA694F921788D4DA26A4</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>BUNDLE_LOADER</key>
+				<string>$(BUILT_PRODUCTS_DIR)/AutoPkgr.app/Contents/MacOS/AutoPkgr</string>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AutoPkgr/AutoPkgr-Prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>AutoPkgrTests/AutoPkgrTests-Info.plist</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>TEST_HOST</key>
+				<string>$(BUNDLE_LOADER)</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>xctest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>1AC86D36195E0972006FDD2B</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BE025CFC19BAEF8800D36345</string>
+				<string>BE025CFD19BAEF8800D36345</string>
+				<string>BE025CF419BAE93400D36345</string>
+				<string>BE025CF519BAE93400D36345</string>
+				<string>1AC98410195CE8510071CAB3</string>
+				<string>1AC98411195CE8520071CAB3</string>
+				<string>1A1BAD9C197A4133008192A7</string>
+				<string>1A1BAD9D197A4133008192A7</string>
+				<string>BEAA76CA19BFD635002D73EE</string>
+				<string>BEAA76CB19BFD635002D73EE</string>
+				<string>6A53625B1988BE59008A949C</string>
+				<string>6A53625C1988BE59008A949C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Feature Classes</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC86D3B195E0AC6006FDD2B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGHostInfo.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC86D3C195E0AC6006FDD2B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGHostInfo.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC86D3D195E0AC6006FDD2B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC86D3C195E0AC6006FDD2B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC98408195CE7D60071CAB3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGConstants.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC98409195CE7D60071CAB3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGConstants.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC9840A195CE7D60071CAB3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC98409195CE7D60071CAB3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC98410195CE8510071CAB3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGEmailer.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC98411195CE8520071CAB3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGEmailer.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC98412195CE8520071CAB3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC98411195CE8520071CAB3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC9841C195CEC350071CAB3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGConfigurationWindowController.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC9841D195CEC350071CAB3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGConfigurationWindowController.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC9841E195CEC360071CAB3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>file.xib</string>
+			<key>path</key>
+			<string>LGConfigurationWindowController.xib</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC9841F195CEC360071CAB3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC9841D195CEC350071CAB3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC98420195CEC360071CAB3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC9841E195CEC360071CAB3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC98423195DF6270071CAB3</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1A2C7FAC19CC9F8300CFF472</string>
+				<string>8BB217F519709A2C00EF8B93</string>
+				<string>1AC98425195DF6350071CAB3</string>
+				<string>1AC98428195DF6DE0071CAB3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC98425195DF6350071CAB3</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>image.png</string>
+			<key>path</key>
+			<string>autopkgr.png</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC98427195DF6350071CAB3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC98425195DF6350071CAB3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1AC98428195DF6DE0071CAB3</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>image.png</string>
+			<key>path</key>
+			<string>autopkgr_alt.png</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1AC98429195DF6DE0071CAB3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AC98428195DF6DE0071CAB3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>349C4BBE0FECE20F0C28E9BE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-AutoPkgrTests.debug.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-AutoPkgrTests/Pods-AutoPkgrTests.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4B8E6E4F9D8944C883A98423</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FF435269A548437DA5380201</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>570AE652B42D4D4D86875A8A</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>61DD19B85D50CC5311395838</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>6A0ACE32196FB349002C7FE4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGRecipes.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6A0ACE33196FB349002C7FE4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGRecipes.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6A0ACE34196FB349002C7FE4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6A0ACE33196FB349002C7FE4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>6A0BABE7196E560000A136BB</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGPopularRepositories.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6A0BABE8196E560000A136BB</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGPopularRepositories.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6A0BABE9196E560000A136BB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6A0BABE8196E560000A136BB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>6A53625B1988BE59008A949C</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGTestPort.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6A53625C1988BE59008A949C</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGTestPort.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6A53625D1988BE59008A949C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6A53625C1988BE59008A949C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>75AC16A7785ECD4E7736EE19</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-AutoPkgrTests/Pods-AutoPkgrTests-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>8B8AB7F01A16A26B00B03C00</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>1A0A869D195CE5DB00A49434</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>2</string>
+			<key>remoteGlobalIDString</key>
+			<string>27780C3A19CF9CD100C77E44</string>
+			<key>remoteInfo</key>
+			<string>mailcore ios</string>
+		</dict>
+		<key>8B8AB7F11A16A26B00B03C00</key>
+		<dict>
+			<key>fileType</key>
+			<string>wrapper.framework</string>
+			<key>isa</key>
+			<string>PBXReferenceProxy</string>
+			<key>path</key>
+			<string>MailCore.framework</string>
+			<key>remoteRef</key>
+			<string>8B8AB7F01A16A26B00B03C00</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>8B8AB7F21A16A26B00B03C00</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>1A0A869D195CE5DB00A49434</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>2</string>
+			<key>remoteGlobalIDString</key>
+			<string>C6B5AE0219F630B3001352A6</string>
+			<key>remoteInfo</key>
+			<string>unittest</string>
+		</dict>
+		<key>8B8AB7F31A16A26B00B03C00</key>
+		<dict>
+			<key>fileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>isa</key>
+			<string>PBXReferenceProxy</string>
+			<key>path</key>
+			<string>unittest.xctest</string>
+			<key>remoteRef</key>
+			<string>8B8AB7F21A16A26B00B03C00</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>8BB217F519709A2C00EF8B93</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>image.png</string>
+			<key>path</key>
+			<string>AutoPkgrIcon.png</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8BB217F619709A2C00EF8B93</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8BB217F519709A2C00EF8B93</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>90C60AB0B9E4D774CB4EA44A</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>04CA360328E704A8E80B244B</string>
+				<string>16E87146BB0135D03CB6ECA8</string>
+				<string>349C4BBE0FECE20F0C28E9BE</string>
+				<string>ADA9DA694F921788D4DA26A4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>930ADF1FA6C29018DAE59FD8</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods-AutoPkgrTests.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>95100698DA9F8FE9BF866A34</key>
+		<dict>
+			<key>fileRef</key>
+			<string>930ADF1FA6C29018DAE59FD8</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>ADA9DA694F921788D4DA26A4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-AutoPkgrTests.release.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-AutoPkgrTests/Pods-AutoPkgrTests.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE025CF419BAE93400D36345</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGAutoPkgTask.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE025CF519BAE93400D36345</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGAutoPkgTask.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE025CF619BAE93400D36345</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE025CF519BAE93400D36345</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE025CF719BAE93400D36345</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE025CF519BAE93400D36345</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE025CFC19BAEF8800D36345</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGAutoPkgSchedule.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE025CFD19BAEF8800D36345</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGAutoPkgSchedule.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE025CFE19BAEF8800D36345</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE025CFD19BAEF8800D36345</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE025CFF19BAEF8800D36345</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE025CFD19BAEF8800D36345</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE0E857719D668F600B25B5E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGHTTPRequest.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE0E857819D668F600B25B5E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGHTTPRequest.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE0E857919D668F600B25B5E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE0E857819D668F600B25B5E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE32178919ED9ACA00A92E5A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGRecipeOverrides.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE32178A19ED9ACA00A92E5A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGRecipeOverrides.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE32178B19ED9ACA00A92E5A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE32178A19ED9ACA00A92E5A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE32178C19EDA15400A92E5A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGTableView.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE32178D19EDA15400A92E5A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGTableView.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE32178E19EDA15400A92E5A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE32178D19EDA15400A92E5A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE34DF2B19AA21E200DC2FAF</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGAutoPkgr.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE39FE5119DFBB0100C1B4A1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>LGDefaults+JSSAddon.h</string>
+			<key>path</key>
+			<string>Custom Catagories/LGDefaults+JSSAddon.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE39FE5219DFBB0100C1B4A1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>LGDefaults+JSSAddon.m</string>
+			<key>path</key>
+			<string>Custom Catagories/LGDefaults+JSSAddon.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE39FE5319DFBB0100C1B4A1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE39FE5219DFBB0100C1B4A1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE39FE5419DFBB2900C1B4A1</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BE77A7FE19E37C910022B6FB</string>
+				<string>BE77A7FF19E37C910022B6FB</string>
+				<string>BE73CDC519E062AC00441443</string>
+				<string>BE73CDC619E062AC00441443</string>
+				<string>BEE8CF1119E0E7F400981C4B</string>
+				<string>BEE8CF1219E0E7F400981C4B</string>
+				<string>BE39FE5119DFBB0100C1B4A1</string>
+				<string>BE39FE5219DFBB0100C1B4A1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Custom Categories</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE40CB7719D4441600A1DABD</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BE94AA7B19BB8A78001A00D0</string>
+				<string>1AC69562195B59EE00D2BD81</string>
+				<string>1AC69563195B59EE00D2BD81</string>
+				<string>1AC9841C195CEC350071CAB3</string>
+				<string>1AC9841D195CEC350071CAB3</string>
+				<string>6A0BABE7196E560000A136BB</string>
+				<string>6A0BABE8196E560000A136BB</string>
+				<string>6A0ACE32196FB349002C7FE4</string>
+				<string>6A0ACE33196FB349002C7FE4</string>
+				<string>BE32178919ED9ACA00A92E5A</string>
+				<string>BE32178A19ED9ACA00A92E5A</string>
+				<string>BE32178C19EDA15400A92E5A</string>
+				<string>BE32178D19EDA15400A92E5A</string>
+				<string>BE57733619D519E400D872A4</string>
+				<string>BE57733719D519E400D872A4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>UI Classes</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE40CB7819D4444D00A1DABD</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BE34DF2B19AA21E200DC2FAF</string>
+				<string>1AC98408195CE7D60071CAB3</string>
+				<string>1AC98409195CE7D60071CAB3</string>
+				<string>BE8799491995BA410082472B</string>
+				<string>BE87994A1995BA410082472B</string>
+				<string>BEFC931B1995F0710074C938</string>
+				<string>BEFC931C1995F0710074C938</string>
+				<string>1AC86D3B195E0AC6006FDD2B</string>
+				<string>1AC86D3C195E0AC6006FDD2B</string>
+				<string>BE0E857719D668F600B25B5E</string>
+				<string>BE0E857819D668F600B25B5E</string>
+				<string>1A979FDE1960BCCC00EE9881</string>
+				<string>1A979FDF1960BCCC00EE9881</string>
+				<string>1A1BAD94197A0407008192A7</string>
+				<string>1A1BAD95197A0407008192A7</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Utility Classes</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE57733619D519E400D872A4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGJSSAddon.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE57733719D519E400D872A4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGJSSAddon.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE57733819D519E400D872A4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE57733719D519E400D872A4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE57AC2A19BA3BBC00BB17B1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE57AC2C19BA3BBC00BB17B1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE57AC2B19BA3BBC00BB17B1</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/Localizable.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE57AC2C19BA3BBC00BB17B1</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BE57AC2B19BA3BBC00BB17B1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>Localizable.strings</string>
+			<key>path</key>
+			<string>..</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE73CDC519E062AC00441443</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>NSString+cleaned.h</string>
+			<key>path</key>
+			<string>Custom Catagories/NSString+cleaned.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE73CDC619E062AC00441443</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>NSString+cleaned.m</string>
+			<key>path</key>
+			<string>Custom Catagories/NSString+cleaned.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE73CDC719E062AC00441443</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE73CDC619E062AC00441443</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE77A7FE19E37C910022B6FB</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>NSImage+statusLight.h</string>
+			<key>path</key>
+			<string>Custom Catagories/NSImage+statusLight.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE77A7FF19E37C910022B6FB</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>NSImage+statusLight.m</string>
+			<key>path</key>
+			<string>Custom Catagories/NSImage+statusLight.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE77A80019E37C910022B6FB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE77A7FF19E37C910022B6FB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE8526B119D5F641007DFA9E</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>SecurityInterface.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/SecurityInterface.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>BE8526B219D5F641007DFA9E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE8526B119D5F641007DFA9E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE8799491995BA410082472B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGDefaults.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE87994A1995BA410082472B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGDefaults.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BE87994B1995BA410082472B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BE87994A1995BA410082472B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BE94AA7B19BB8A78001A00D0</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGProgressDelegate.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BEAA76CA19BFD635002D73EE</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGInstaller.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BEAA76CB19BFD635002D73EE</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGInstaller.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BEAA76CC19BFD635002D73EE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BEAA76CB19BFD635002D73EE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BECFF2B619CA9854004C2721</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string># Update build number with number of git commits if in release mode
 
-/* Begin PBXBuildFile section */
-		1A0A86AF195CE63900A49434 /* MailCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A0A86AE195CE5DC00A49434 /* MailCore.framework */; };
-		1A0A86B1195CE69300A49434 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A0A86B0195CE69300A49434 /* Security.framework */; };
-		1A0A86B5195CE6D800A49434 /* MailCore.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1A0A86AE195CE5DC00A49434 /* MailCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		1A1BAD96197A0407008192A7 /* LGVersionComparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A1BAD95197A0407008192A7 /* LGVersionComparator.m */; };
-		1A1BAD9E197A4133008192A7 /* LGGitHubJSONLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A1BAD9D197A4133008192A7 /* LGGitHubJSONLoader.m */; };
-		1A2C7FAE19CC9F8300CFF472 /* codesign.py in Resources */ = {isa = PBXBuildFile; fileRef = 1A2C7FAD19CC9F8300CFF472 /* codesign.py */; };
-		1A979FE01960BCCC00EE9881 /* LGUnzipper.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A979FDF1960BCCC00EE9881 /* LGUnzipper.m */; };
-		1AC69551195B59ED00D2BD81 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AC69550195B59ED00D2BD81 /* Cocoa.framework */; };
-		1AC6955B195B59ED00D2BD81 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1AC69559195B59ED00D2BD81 /* InfoPlist.strings */; };
-		1AC6955D195B59EE00D2BD81 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC6955C195B59ED00D2BD81 /* main.m */; };
-		1AC69561195B59EE00D2BD81 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 1AC6955F195B59EE00D2BD81 /* Credits.rtf */; };
-		1AC69564195B59EE00D2BD81 /* LGAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC69563195B59EE00D2BD81 /* LGAppDelegate.m */; };
-		1AC69567195B59EE00D2BD81 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1AC69565195B59EE00D2BD81 /* MainMenu.xib */; };
-		1AC69569195B59EE00D2BD81 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1AC69568195B59EE00D2BD81 /* Images.xcassets */; };
-		1AC69570195B59EE00D2BD81 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AC6956F195B59EE00D2BD81 /* XCTest.framework */; };
-		1AC69571195B59EE00D2BD81 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AC69550195B59ED00D2BD81 /* Cocoa.framework */; };
-		1AC69579195B59EE00D2BD81 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1AC69577195B59EE00D2BD81 /* InfoPlist.strings */; };
-		1AC6957B195B59EE00D2BD81 /* AutoPkgrTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC6957A195B59EE00D2BD81 /* AutoPkgrTests.m */; };
-		1AC86D3D195E0AC6006FDD2B /* LGHostInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC86D3C195E0AC6006FDD2B /* LGHostInfo.m */; };
-		1AC9840A195CE7D60071CAB3 /* LGConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC98409195CE7D60071CAB3 /* LGConstants.m */; };
-		1AC98412195CE8520071CAB3 /* LGEmailer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC98411195CE8520071CAB3 /* LGEmailer.m */; };
-		1AC9841F195CEC360071CAB3 /* LGConfigurationWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC9841D195CEC350071CAB3 /* LGConfigurationWindowController.m */; };
-		1AC98420195CEC360071CAB3 /* LGConfigurationWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1AC9841E195CEC360071CAB3 /* LGConfigurationWindowController.xib */; };
-		1AC98427195DF6350071CAB3 /* autopkgr.png in Resources */ = {isa = PBXBuildFile; fileRef = 1AC98425195DF6350071CAB3 /* autopkgr.png */; };
-		1AC98429195DF6DE0071CAB3 /* autopkgr_alt.png in Resources */ = {isa = PBXBuildFile; fileRef = 1AC98428195DF6DE0071CAB3 /* autopkgr_alt.png */; };
-		4B8E6E4F9D8944C883A98423 /* libPods-AutoPkgr.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FF435269A548437DA5380201 /* libPods-AutoPkgr.a */; };
-		6A0ACE34196FB349002C7FE4 /* LGRecipes.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A0ACE33196FB349002C7FE4 /* LGRecipes.m */; };
-		6A0BABE9196E560000A136BB /* LGPopularRepositories.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A0BABE8196E560000A136BB /* LGPopularRepositories.m */; };
-		6A53625D1988BE59008A949C /* LGTestPort.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A53625C1988BE59008A949C /* LGTestPort.m */; };
-		8BB217F619709A2C00EF8B93 /* AutoPkgrIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 8BB217F519709A2C00EF8B93 /* AutoPkgrIcon.png */; };
-		BE025CF619BAE93400D36345 /* LGAutoPkgTask.m in Sources */ = {isa = PBXBuildFile; fileRef = BE025CF519BAE93400D36345 /* LGAutoPkgTask.m */; };
-		BE025CF719BAE93400D36345 /* LGAutoPkgTask.m in Sources */ = {isa = PBXBuildFile; fileRef = BE025CF519BAE93400D36345 /* LGAutoPkgTask.m */; };
-		BE025CFE19BAEF8800D36345 /* LGAutoPkgSchedule.m in Sources */ = {isa = PBXBuildFile; fileRef = BE025CFD19BAEF8800D36345 /* LGAutoPkgSchedule.m */; };
-		BE025CFF19BAEF8800D36345 /* LGAutoPkgSchedule.m in Sources */ = {isa = PBXBuildFile; fileRef = BE025CFD19BAEF8800D36345 /* LGAutoPkgSchedule.m */; };
-		BE0E857919D668F600B25B5E /* LGHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE0E857819D668F600B25B5E /* LGHTTPRequest.m */; };
-		BE32178B19ED9ACA00A92E5A /* LGRecipeOverrides.m in Sources */ = {isa = PBXBuildFile; fileRef = BE32178A19ED9ACA00A92E5A /* LGRecipeOverrides.m */; };
-		BE32178E19EDA15400A92E5A /* LGTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = BE32178D19EDA15400A92E5A /* LGTableView.m */; };
-		BE39FE5319DFBB0100C1B4A1 /* LGDefaults+JSSAddon.m in Sources */ = {isa = PBXBuildFile; fileRef = BE39FE5219DFBB0100C1B4A1 /* LGDefaults+JSSAddon.m */; };
-		BE57733819D519E400D872A4 /* LGJSSAddon.m in Sources */ = {isa = PBXBuildFile; fileRef = BE57733719D519E400D872A4 /* LGJSSAddon.m */; };
-		BE57AC2A19BA3BBC00BB17B1 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BE57AC2C19BA3BBC00BB17B1 /* Localizable.strings */; };
-		BE73CDC719E062AC00441443 /* NSString+cleaned.m in Sources */ = {isa = PBXBuildFile; fileRef = BE73CDC619E062AC00441443 /* NSString+cleaned.m */; };
-		BE77A80019E37C910022B6FB /* NSImage+statusLight.m in Sources */ = {isa = PBXBuildFile; fileRef = BE77A7FF19E37C910022B6FB /* NSImage+statusLight.m */; };
-		BE8526B219D5F641007DFA9E /* SecurityInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE8526B119D5F641007DFA9E /* SecurityInterface.framework */; };
-		BE87994B1995BA410082472B /* LGDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = BE87994A1995BA410082472B /* LGDefaults.m */; };
-		BEAA76CC19BFD635002D73EE /* LGInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = BEAA76CB19BFD635002D73EE /* LGInstaller.m */; };
-		BEE8CF1319E0E7F400981C4B /* NSTextField+setSafeStringValue.m in Sources */ = {isa = PBXBuildFile; fileRef = BEE8CF1219E0E7F400981C4B /* NSTextField+setSafeStringValue.m */; };
-		BEFC931D1995F0710074C938 /* LGError.m in Sources */ = {isa = PBXBuildFile; fileRef = BEFC931C1995F0710074C938 /* LGError.m */; };
-/* End PBXBuildFile section */
+[[ ${CONFIGURATION} != "Release" ]] &amp;&amp; exit 0
 
-/* Begin PBXContainerItemProxy section */
-		1A0A86A5195CE5DC00A49434 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = C64EA537169E772200778456;
-			remoteInfo = "static mailcore2 osx";
-		};
-		1A0A86A7195CE5DC00A49434 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = C6BA2C191705F4E6003F0E9E;
-			remoteInfo = "static mailcore2 ios";
-		};
-		1A0A86A9195CE5DC00A49434 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = C64EA78C169F259200778456;
-			remoteInfo = tests;
-		};
-		1A0A86AB195CE5DC00A49434 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = C6A81B911706840C00882C15;
-			remoteInfo = "test-ios";
-		};
-		1A0A86AD195CE5DC00A49434 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = C6BD288D170BD71100A91AC1;
-			remoteInfo = "mailcore osx";
-		};
-		1A0A86B2195CE6B500A49434 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = C6BD288C170BD71100A91AC1;
-			remoteInfo = "mailcore osx";
-		};
-		1AC69572195B59EE00D2BD81 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1AC69545195B59ED00D2BD81 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1AC6954C195B59ED00D2BD81;
-			remoteInfo = AutoPkgr;
-		};
-		8B8AB7F01A16A26B00B03C00 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 27780C3A19CF9CD100C77E44;
-			remoteInfo = "mailcore ios";
-		};
-		8B8AB7F21A16A26B00B03C00 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = C6B5AE0219F630B3001352A6;
-			remoteInfo = unittest;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		1A0A86B4195CE6BF00A49434 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				1A0A86B5195CE6D800A49434 /* MailCore.framework in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
-/* Begin PBXFileReference section */
-		04CA360328E704A8E80B244B /* Pods-AutoPkgr.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoPkgr.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AutoPkgr/Pods-AutoPkgr.debug.xcconfig"; sourceTree = "<group>"; };
-		16E87146BB0135D03CB6ECA8 /* Pods-AutoPkgr.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoPkgr.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutoPkgr/Pods-AutoPkgr.release.xcconfig"; sourceTree = "<group>"; };
-		1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = mailcore2.xcodeproj; path = "mailcore2/build-mac/mailcore2.xcodeproj"; sourceTree = SOURCE_ROOT; };
-		1A0A86B0195CE69300A49434 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
-		1A1BAD94197A0407008192A7 /* LGVersionComparator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGVersionComparator.h; sourceTree = "<group>"; };
-		1A1BAD95197A0407008192A7 /* LGVersionComparator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGVersionComparator.m; sourceTree = "<group>"; };
-		1A1BAD9C197A4133008192A7 /* LGGitHubJSONLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGGitHubJSONLoader.h; sourceTree = "<group>"; };
-		1A1BAD9D197A4133008192A7 /* LGGitHubJSONLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGGitHubJSONLoader.m; sourceTree = "<group>"; };
-		1A2C7FAD19CC9F8300CFF472 /* codesign.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = codesign.py; sourceTree = "<group>"; };
-		1A979FDE1960BCCC00EE9881 /* LGUnzipper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGUnzipper.h; sourceTree = "<group>"; };
-		1A979FDF1960BCCC00EE9881 /* LGUnzipper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGUnzipper.m; sourceTree = "<group>"; };
-		1AC6954D195B59ED00D2BD81 /* AutoPkgr.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AutoPkgr.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		1AC69550195B59ED00D2BD81 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
-		1AC69553195B59ED00D2BD81 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
-		1AC69554195B59ED00D2BD81 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
-		1AC69555195B59ED00D2BD81 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		1AC69558195B59ED00D2BD81 /* AutoPkgr-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "AutoPkgr-Info.plist"; sourceTree = "<group>"; };
-		1AC6955A195B59ED00D2BD81 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		1AC6955C195B59ED00D2BD81 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		1AC6955E195B59EE00D2BD81 /* AutoPkgr-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AutoPkgr-Prefix.pch"; sourceTree = "<group>"; };
-		1AC69560195B59EE00D2BD81 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = en; path = en.lproj/Credits.rtf; sourceTree = "<group>"; };
-		1AC69562195B59EE00D2BD81 /* LGAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LGAppDelegate.h; sourceTree = "<group>"; };
-		1AC69563195B59EE00D2BD81 /* LGAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LGAppDelegate.m; sourceTree = "<group>"; };
-		1AC69566195B59EE00D2BD81 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
-		1AC69568195B59EE00D2BD81 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		1AC6956E195B59EE00D2BD81 /* AutoPkgrTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AutoPkgrTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		1AC6956F195B59EE00D2BD81 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		1AC69576195B59EE00D2BD81 /* AutoPkgrTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "AutoPkgrTests-Info.plist"; sourceTree = "<group>"; };
-		1AC69578195B59EE00D2BD81 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		1AC6957A195B59EE00D2BD81 /* AutoPkgrTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoPkgrTests.m; sourceTree = "<group>"; };
-		1AC86D3B195E0AC6006FDD2B /* LGHostInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGHostInfo.h; sourceTree = "<group>"; };
-		1AC86D3C195E0AC6006FDD2B /* LGHostInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGHostInfo.m; sourceTree = "<group>"; };
-		1AC98408195CE7D60071CAB3 /* LGConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGConstants.h; sourceTree = "<group>"; };
-		1AC98409195CE7D60071CAB3 /* LGConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGConstants.m; sourceTree = "<group>"; };
-		1AC98410195CE8510071CAB3 /* LGEmailer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGEmailer.h; sourceTree = "<group>"; };
-		1AC98411195CE8520071CAB3 /* LGEmailer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGEmailer.m; sourceTree = "<group>"; };
-		1AC9841C195CEC350071CAB3 /* LGConfigurationWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGConfigurationWindowController.h; sourceTree = "<group>"; };
-		1AC9841D195CEC350071CAB3 /* LGConfigurationWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGConfigurationWindowController.m; sourceTree = "<group>"; };
-		1AC9841E195CEC360071CAB3 /* LGConfigurationWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LGConfigurationWindowController.xib; sourceTree = "<group>"; };
-		1AC98425195DF6350071CAB3 /* autopkgr.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = autopkgr.png; sourceTree = "<group>"; };
-		1AC98428195DF6DE0071CAB3 /* autopkgr_alt.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = autopkgr_alt.png; sourceTree = "<group>"; };
-		6A0ACE32196FB349002C7FE4 /* LGRecipes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGRecipes.h; sourceTree = "<group>"; };
-		6A0ACE33196FB349002C7FE4 /* LGRecipes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGRecipes.m; sourceTree = "<group>"; };
-		6A0BABE7196E560000A136BB /* LGPopularRepositories.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGPopularRepositories.h; sourceTree = "<group>"; };
-		6A0BABE8196E560000A136BB /* LGPopularRepositories.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGPopularRepositories.m; sourceTree = "<group>"; };
-		6A53625B1988BE59008A949C /* LGTestPort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGTestPort.h; sourceTree = "<group>"; };
-		6A53625C1988BE59008A949C /* LGTestPort.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGTestPort.m; sourceTree = "<group>"; };
-		8BB217F519709A2C00EF8B93 /* AutoPkgrIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AutoPkgrIcon.png; sourceTree = "<group>"; };
-		BE025CF419BAE93400D36345 /* LGAutoPkgTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGAutoPkgTask.h; sourceTree = "<group>"; };
-		BE025CF519BAE93400D36345 /* LGAutoPkgTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGAutoPkgTask.m; sourceTree = "<group>"; };
-		BE025CFC19BAEF8800D36345 /* LGAutoPkgSchedule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGAutoPkgSchedule.h; sourceTree = "<group>"; };
-		BE025CFD19BAEF8800D36345 /* LGAutoPkgSchedule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGAutoPkgSchedule.m; sourceTree = "<group>"; };
-		BE0E857719D668F600B25B5E /* LGHTTPRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGHTTPRequest.h; sourceTree = "<group>"; };
-		BE0E857819D668F600B25B5E /* LGHTTPRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGHTTPRequest.m; sourceTree = "<group>"; };
-		BE32178919ED9ACA00A92E5A /* LGRecipeOverrides.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGRecipeOverrides.h; sourceTree = "<group>"; };
-		BE32178A19ED9ACA00A92E5A /* LGRecipeOverrides.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGRecipeOverrides.m; sourceTree = "<group>"; };
-		BE32178C19EDA15400A92E5A /* LGTableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGTableView.h; sourceTree = "<group>"; };
-		BE32178D19EDA15400A92E5A /* LGTableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGTableView.m; sourceTree = "<group>"; };
-		BE34DF2B19AA21E200DC2FAF /* LGAutoPkgr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LGAutoPkgr.h; sourceTree = "<group>"; };
-		BE39FE5119DFBB0100C1B4A1 /* LGDefaults+JSSAddon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "LGDefaults+JSSAddon.h"; path = "Custom Catagories/LGDefaults+JSSAddon.h"; sourceTree = "<group>"; };
-		BE39FE5219DFBB0100C1B4A1 /* LGDefaults+JSSAddon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "LGDefaults+JSSAddon.m"; path = "Custom Catagories/LGDefaults+JSSAddon.m"; sourceTree = "<group>"; };
-		BE57733619D519E400D872A4 /* LGJSSAddon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGJSSAddon.h; sourceTree = "<group>"; };
-		BE57733719D519E400D872A4 /* LGJSSAddon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGJSSAddon.m; sourceTree = "<group>"; };
-		BE57AC2B19BA3BBC00BB17B1 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		BE73CDC519E062AC00441443 /* NSString+cleaned.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+cleaned.h"; path = "Custom Catagories/NSString+cleaned.h"; sourceTree = "<group>"; };
-		BE73CDC619E062AC00441443 /* NSString+cleaned.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+cleaned.m"; path = "Custom Catagories/NSString+cleaned.m"; sourceTree = "<group>"; };
-		BE77A7FE19E37C910022B6FB /* NSImage+statusLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSImage+statusLight.h"; path = "Custom Catagories/NSImage+statusLight.h"; sourceTree = "<group>"; };
-		BE77A7FF19E37C910022B6FB /* NSImage+statusLight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSImage+statusLight.m"; path = "Custom Catagories/NSImage+statusLight.m"; sourceTree = "<group>"; };
-		BE8526B119D5F641007DFA9E /* SecurityInterface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SecurityInterface.framework; path = System/Library/Frameworks/SecurityInterface.framework; sourceTree = SDKROOT; };
-		BE8799491995BA410082472B /* LGDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGDefaults.h; sourceTree = "<group>"; };
-		BE87994A1995BA410082472B /* LGDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGDefaults.m; sourceTree = "<group>"; };
-		BE94AA7B19BB8A78001A00D0 /* LGProgressDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LGProgressDelegate.h; sourceTree = "<group>"; };
-		BEAA76CA19BFD635002D73EE /* LGInstaller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGInstaller.h; sourceTree = "<group>"; };
-		BEAA76CB19BFD635002D73EE /* LGInstaller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGInstaller.m; sourceTree = "<group>"; };
-		BEE8CF1119E0E7F400981C4B /* NSTextField+setSafeStringValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSTextField+setSafeStringValue.h"; path = "Custom Catagories/NSTextField+setSafeStringValue.h"; sourceTree = "<group>"; };
-		BEE8CF1219E0E7F400981C4B /* NSTextField+setSafeStringValue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSTextField+setSafeStringValue.m"; path = "Custom Catagories/NSTextField+setSafeStringValue.m"; sourceTree = "<group>"; };
-		BEFC931B1995F0710074C938 /* LGError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGError.h; sourceTree = "<group>"; };
-		BEFC931C1995F0710074C938 /* LGError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGError.m; sourceTree = "<group>"; };
-		FF435269A548437DA5380201 /* libPods-AutoPkgr.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AutoPkgr.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		1AC6954A195B59ED00D2BD81 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BE8526B219D5F641007DFA9E /* SecurityInterface.framework in Frameworks */,
-				1A0A86B1195CE69300A49434 /* Security.framework in Frameworks */,
-				1A0A86AF195CE63900A49434 /* MailCore.framework in Frameworks */,
-				1AC69551195B59ED00D2BD81 /* Cocoa.framework in Frameworks */,
-				4B8E6E4F9D8944C883A98423 /* libPods-AutoPkgr.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		1AC6956B195B59EE00D2BD81 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1AC69571195B59EE00D2BD81 /* Cocoa.framework in Frameworks */,
-				1AC69570195B59EE00D2BD81 /* XCTest.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		1A0A869E195CE5DB00A49434 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				1A0A86A6195CE5DC00A49434 /* libMailCore.a */,
-				1A0A86A8195CE5DC00A49434 /* libMailCore-ios.a */,
-				1A0A86AA195CE5DC00A49434 /* tests */,
-				1A0A86AC195CE5DC00A49434 /* test-ios.app */,
-				1A0A86AE195CE5DC00A49434 /* MailCore.framework */,
-				8B8AB7F11A16A26B00B03C00 /* MailCore.framework */,
-				8B8AB7F31A16A26B00B03C00 /* unittest.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		1A2C7FAC19CC9F8300CFF472 /* scripts */ = {
-			isa = PBXGroup;
-			children = (
-				1A2C7FAD19CC9F8300CFF472 /* codesign.py */,
-			);
-			path = scripts;
-			sourceTree = SOURCE_ROOT;
-		};
-		1AC69544195B59ED00D2BD81 = {
-			isa = PBXGroup;
-			children = (
-				1AC69556195B59ED00D2BD81 /* AutoPkgr */,
-				1AC6954F195B59ED00D2BD81 /* Frameworks */,
-				1AC6954E195B59ED00D2BD81 /* Products */,
-				1AC69574195B59EE00D2BD81 /* AutoPkgrTests */,
-				1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */,
-				90C60AB0B9E4D774CB4EA44A /* Pods */,
-			);
-			sourceTree = "<group>";
-		};
-		1AC6954E195B59ED00D2BD81 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				1AC6954D195B59ED00D2BD81 /* AutoPkgr.app */,
-				1AC6956E195B59EE00D2BD81 /* AutoPkgrTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		1AC6954F195B59ED00D2BD81 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BE8526B119D5F641007DFA9E /* SecurityInterface.framework */,
-				1A0A86B0195CE69300A49434 /* Security.framework */,
-				1AC69550195B59ED00D2BD81 /* Cocoa.framework */,
-				1AC6956F195B59EE00D2BD81 /* XCTest.framework */,
-				1AC69552195B59ED00D2BD81 /* Other Frameworks */,
-				FF435269A548437DA5380201 /* libPods-AutoPkgr.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		1AC69552195B59ED00D2BD81 /* Other Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				1AC69553195B59ED00D2BD81 /* AppKit.framework */,
-				1AC69554195B59ED00D2BD81 /* CoreData.framework */,
-				1AC69555195B59ED00D2BD81 /* Foundation.framework */,
-			);
-			name = "Other Frameworks";
-			sourceTree = "<group>";
-		};
-		1AC69556195B59ED00D2BD81 /* AutoPkgr */ = {
-			isa = PBXGroup;
-			children = (
-				1AC86D36195E0972006FDD2B /* Feature Classes */,
-				BE40CB7719D4441600A1DABD /* UI Classes */,
-				BE40CB7819D4444D00A1DABD /* Utility Classes */,
-				BE39FE5419DFBB2900C1B4A1 /* Custom Categories */,
-				1AC9841E195CEC360071CAB3 /* LGConfigurationWindowController.xib */,
-				1AC69565195B59EE00D2BD81 /* MainMenu.xib */,
-				1AC69568195B59EE00D2BD81 /* Images.xcassets */,
-				1AC98423195DF6270071CAB3 /* Resources */,
-				1AC69557195B59ED00D2BD81 /* Supporting Files */,
-			);
-			path = AutoPkgr;
-			sourceTree = "<group>";
-		};
-		1AC69557195B59ED00D2BD81 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				1AC69558195B59ED00D2BD81 /* AutoPkgr-Info.plist */,
-				1AC69559195B59ED00D2BD81 /* InfoPlist.strings */,
-				BE57AC2C19BA3BBC00BB17B1 /* Localizable.strings */,
-				1AC6955C195B59ED00D2BD81 /* main.m */,
-				1AC6955E195B59EE00D2BD81 /* AutoPkgr-Prefix.pch */,
-				1AC6955F195B59EE00D2BD81 /* Credits.rtf */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		1AC69574195B59EE00D2BD81 /* AutoPkgrTests */ = {
-			isa = PBXGroup;
-			children = (
-				1AC6957A195B59EE00D2BD81 /* AutoPkgrTests.m */,
-				1AC69575195B59EE00D2BD81 /* Supporting Files */,
-			);
-			path = AutoPkgrTests;
-			sourceTree = "<group>";
-		};
-		1AC69575195B59EE00D2BD81 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				1AC69576195B59EE00D2BD81 /* AutoPkgrTests-Info.plist */,
-				1AC69577195B59EE00D2BD81 /* InfoPlist.strings */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		1AC86D36195E0972006FDD2B /* Feature Classes */ = {
-			isa = PBXGroup;
-			children = (
-				BE025CFC19BAEF8800D36345 /* LGAutoPkgSchedule.h */,
-				BE025CFD19BAEF8800D36345 /* LGAutoPkgSchedule.m */,
-				BE025CF419BAE93400D36345 /* LGAutoPkgTask.h */,
-				BE025CF519BAE93400D36345 /* LGAutoPkgTask.m */,
-				1AC98410195CE8510071CAB3 /* LGEmailer.h */,
-				1AC98411195CE8520071CAB3 /* LGEmailer.m */,
-				1A1BAD9C197A4133008192A7 /* LGGitHubJSONLoader.h */,
-				1A1BAD9D197A4133008192A7 /* LGGitHubJSONLoader.m */,
-				BEAA76CA19BFD635002D73EE /* LGInstaller.h */,
-				BEAA76CB19BFD635002D73EE /* LGInstaller.m */,
-				6A53625B1988BE59008A949C /* LGTestPort.h */,
-				6A53625C1988BE59008A949C /* LGTestPort.m */,
-			);
-			name = "Feature Classes";
-			sourceTree = "<group>";
-		};
-		1AC98423195DF6270071CAB3 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				1A2C7FAC19CC9F8300CFF472 /* scripts */,
-				8BB217F519709A2C00EF8B93 /* AutoPkgrIcon.png */,
-				1AC98425195DF6350071CAB3 /* autopkgr.png */,
-				1AC98428195DF6DE0071CAB3 /* autopkgr_alt.png */,
-			);
-			name = Resources;
-			sourceTree = "<group>";
-		};
-		90C60AB0B9E4D774CB4EA44A /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				04CA360328E704A8E80B244B /* Pods-AutoPkgr.debug.xcconfig */,
-				16E87146BB0135D03CB6ECA8 /* Pods-AutoPkgr.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		BE39FE5419DFBB2900C1B4A1 /* Custom Categories */ = {
-			isa = PBXGroup;
-			children = (
-				BE77A7FE19E37C910022B6FB /* NSImage+statusLight.h */,
-				BE77A7FF19E37C910022B6FB /* NSImage+statusLight.m */,
-				BE73CDC519E062AC00441443 /* NSString+cleaned.h */,
-				BE73CDC619E062AC00441443 /* NSString+cleaned.m */,
-				BEE8CF1119E0E7F400981C4B /* NSTextField+setSafeStringValue.h */,
-				BEE8CF1219E0E7F400981C4B /* NSTextField+setSafeStringValue.m */,
-				BE39FE5119DFBB0100C1B4A1 /* LGDefaults+JSSAddon.h */,
-				BE39FE5219DFBB0100C1B4A1 /* LGDefaults+JSSAddon.m */,
-			);
-			name = "Custom Categories";
-			sourceTree = "<group>";
-		};
-		BE40CB7719D4441600A1DABD /* UI Classes */ = {
-			isa = PBXGroup;
-			children = (
-				BE94AA7B19BB8A78001A00D0 /* LGProgressDelegate.h */,
-				1AC69562195B59EE00D2BD81 /* LGAppDelegate.h */,
-				1AC69563195B59EE00D2BD81 /* LGAppDelegate.m */,
-				1AC9841C195CEC350071CAB3 /* LGConfigurationWindowController.h */,
-				1AC9841D195CEC350071CAB3 /* LGConfigurationWindowController.m */,
-				6A0BABE7196E560000A136BB /* LGPopularRepositories.h */,
-				6A0BABE8196E560000A136BB /* LGPopularRepositories.m */,
-				6A0ACE32196FB349002C7FE4 /* LGRecipes.h */,
-				6A0ACE33196FB349002C7FE4 /* LGRecipes.m */,
-				BE32178919ED9ACA00A92E5A /* LGRecipeOverrides.h */,
-				BE32178A19ED9ACA00A92E5A /* LGRecipeOverrides.m */,
-				BE32178C19EDA15400A92E5A /* LGTableView.h */,
-				BE32178D19EDA15400A92E5A /* LGTableView.m */,
-				BE57733619D519E400D872A4 /* LGJSSAddon.h */,
-				BE57733719D519E400D872A4 /* LGJSSAddon.m */,
-			);
-			name = "UI Classes";
-			sourceTree = "<group>";
-		};
-		BE40CB7819D4444D00A1DABD /* Utility Classes */ = {
-			isa = PBXGroup;
-			children = (
-				BE34DF2B19AA21E200DC2FAF /* LGAutoPkgr.h */,
-				1AC98408195CE7D60071CAB3 /* LGConstants.h */,
-				1AC98409195CE7D60071CAB3 /* LGConstants.m */,
-				BE8799491995BA410082472B /* LGDefaults.h */,
-				BE87994A1995BA410082472B /* LGDefaults.m */,
-				BEFC931B1995F0710074C938 /* LGError.h */,
-				BEFC931C1995F0710074C938 /* LGError.m */,
-				1AC86D3B195E0AC6006FDD2B /* LGHostInfo.h */,
-				1AC86D3C195E0AC6006FDD2B /* LGHostInfo.m */,
-				BE0E857719D668F600B25B5E /* LGHTTPRequest.h */,
-				BE0E857819D668F600B25B5E /* LGHTTPRequest.m */,
-				1A979FDE1960BCCC00EE9881 /* LGUnzipper.h */,
-				1A979FDF1960BCCC00EE9881 /* LGUnzipper.m */,
-				1A1BAD94197A0407008192A7 /* LGVersionComparator.h */,
-				1A1BAD95197A0407008192A7 /* LGVersionComparator.m */,
-			);
-			name = "Utility Classes";
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXNativeTarget section */
-		1AC6954C195B59ED00D2BD81 /* AutoPkgr */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 1AC6957E195B59EE00D2BD81 /* Build configuration list for PBXNativeTarget "AutoPkgr" */;
-			buildPhases = (
-				570AE652B42D4D4D86875A8A /* Check Pods Manifest.lock */,
-				BECFF2B619CA9854004C2721 /* ShellScript */,
-				1AC69549195B59ED00D2BD81 /* Sources */,
-				1AC6954A195B59ED00D2BD81 /* Frameworks */,
-				1AC6954B195B59ED00D2BD81 /* Resources */,
-				1A0A86B4195CE6BF00A49434 /* CopyFiles */,
-				C97E222596F14727B875BF98 /* Copy Pods Resources */,
-				1A56282C19CC01D600980AB9 /* ShellScript */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				1A0A86B3195CE6B500A49434 /* PBXTargetDependency */,
-			);
-			name = AutoPkgr;
-			productName = AutoPkgr;
-			productReference = 1AC6954D195B59ED00D2BD81 /* AutoPkgr.app */;
-			productType = "com.apple.product-type.application";
-		};
-		1AC6956D195B59EE00D2BD81 /* AutoPkgrTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 1AC69581195B59EE00D2BD81 /* Build configuration list for PBXNativeTarget "AutoPkgrTests" */;
-			buildPhases = (
-				1AC6956A195B59EE00D2BD81 /* Sources */,
-				1AC6956B195B59EE00D2BD81 /* Frameworks */,
-				1AC6956C195B59EE00D2BD81 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				1AC69573195B59EE00D2BD81 /* PBXTargetDependency */,
-			);
-			name = AutoPkgrTests;
-			productName = AutoPkgrTests;
-			productReference = 1AC6956E195B59EE00D2BD81 /* AutoPkgrTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		1AC69545195B59ED00D2BD81 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				CLASSPREFIX = LG;
-				LastUpgradeCheck = 0600;
-				ORGANIZATIONNAME = "The Linde Group, Inc.";
-				TargetAttributes = {
-					1AC6956D195B59EE00D2BD81 = {
-						TestTargetID = 1AC6954C195B59ED00D2BD81;
-					};
-				};
-			};
-			buildConfigurationList = 1AC69548195B59ED00D2BD81 /* Build configuration list for PBXProject "AutoPkgr" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
-			mainGroup = 1AC69544195B59ED00D2BD81;
-			productRefGroup = 1AC6954E195B59ED00D2BD81 /* Products */;
-			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 1A0A869E195CE5DB00A49434 /* Products */;
-					ProjectRef = 1A0A869D195CE5DB00A49434 /* mailcore2.xcodeproj */;
-				},
-			);
-			projectRoot = "";
-			targets = (
-				1AC6954C195B59ED00D2BD81 /* AutoPkgr */,
-				1AC6956D195B59EE00D2BD81 /* AutoPkgrTests */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		1A0A86A6195CE5DC00A49434 /* libMailCore.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libMailCore.a;
-			remoteRef = 1A0A86A5195CE5DC00A49434 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		1A0A86A8195CE5DC00A49434 /* libMailCore-ios.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libMailCore-ios.a";
-			remoteRef = 1A0A86A7195CE5DC00A49434 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		1A0A86AA195CE5DC00A49434 /* tests */ = {
-			isa = PBXReferenceProxy;
-			fileType = "compiled.mach-o.executable";
-			path = tests;
-			remoteRef = 1A0A86A9195CE5DC00A49434 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		1A0A86AC195CE5DC00A49434 /* test-ios.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = "test-ios.app";
-			remoteRef = 1A0A86AB195CE5DC00A49434 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		1A0A86AE195CE5DC00A49434 /* MailCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = MailCore.framework;
-			remoteRef = 1A0A86AD195CE5DC00A49434 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		8B8AB7F11A16A26B00B03C00 /* MailCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = MailCore.framework;
-			remoteRef = 8B8AB7F01A16A26B00B03C00 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		8B8AB7F31A16A26B00B03C00 /* unittest.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = unittest.xctest;
-			remoteRef = 8B8AB7F21A16A26B00B03C00 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
-
-/* Begin PBXResourcesBuildPhase section */
-		1AC6954B195B59ED00D2BD81 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1AC98429195DF6DE0071CAB3 /* autopkgr_alt.png in Resources */,
-				8BB217F619709A2C00EF8B93 /* AutoPkgrIcon.png in Resources */,
-				1AC6955B195B59ED00D2BD81 /* InfoPlist.strings in Resources */,
-				1AC69569195B59EE00D2BD81 /* Images.xcassets in Resources */,
-				1A2C7FAE19CC9F8300CFF472 /* codesign.py in Resources */,
-				1AC98420195CEC360071CAB3 /* LGConfigurationWindowController.xib in Resources */,
-				BE57AC2A19BA3BBC00BB17B1 /* Localizable.strings in Resources */,
-				1AC98427195DF6350071CAB3 /* autopkgr.png in Resources */,
-				1AC69561195B59EE00D2BD81 /* Credits.rtf in Resources */,
-				1AC69567195B59EE00D2BD81 /* MainMenu.xib in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		1AC6956C195B59EE00D2BD81 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1AC69579195B59EE00D2BD81 /* InfoPlist.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		1A56282C19CC01D600980AB9 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PROJECT_DIR}/scripts/codesign.py\"";
-		};
-		570AE652B42D4D4D86875A8A /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		BECFF2B619CA9854004C2721 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Update build number with number of git commits if in release mode\n\n[[ ${CONFIGURATION} != \"Release\" ]] && exit 0\n\nbuildNumber=$(git rev-list HEAD | wc -l | tr -d ' ')\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $buildNumber\" \"${PROJECT_DIR}/${INFOPLIST_FILE}\"\n";
-		};
-		C97E222596F14727B875BF98 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AutoPkgr/Pods-AutoPkgr-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		1AC69549195B59ED00D2BD81 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1AC6955D195B59EE00D2BD81 /* main.m in Sources */,
-				1AC69564195B59EE00D2BD81 /* LGAppDelegate.m in Sources */,
-				1AC9841F195CEC360071CAB3 /* LGConfigurationWindowController.m in Sources */,
-				1AC9840A195CE7D60071CAB3 /* LGConstants.m in Sources */,
-				BE87994B1995BA410082472B /* LGDefaults.m in Sources */,
-				1AC86D3D195E0AC6006FDD2B /* LGHostInfo.m in Sources */,
-				BE025CF619BAE93400D36345 /* LGAutoPkgTask.m in Sources */,
-				BE025CFE19BAEF8800D36345 /* LGAutoPkgSchedule.m in Sources */,
-				1AC98412195CE8520071CAB3 /* LGEmailer.m in Sources */,
-				BEAA76CC19BFD635002D73EE /* LGInstaller.m in Sources */,
-				6A0ACE34196FB349002C7FE4 /* LGRecipes.m in Sources */,
-				BE32178B19ED9ACA00A92E5A /* LGRecipeOverrides.m in Sources */,
-				6A0BABE9196E560000A136BB /* LGPopularRepositories.m in Sources */,
-				BE57733819D519E400D872A4 /* LGJSSAddon.m in Sources */,
-				BE0E857919D668F600B25B5E /* LGHTTPRequest.m in Sources */,
-				1A1BAD9E197A4133008192A7 /* LGGitHubJSONLoader.m in Sources */,
-				BE32178E19EDA15400A92E5A /* LGTableView.m in Sources */,
-				6A53625D1988BE59008A949C /* LGTestPort.m in Sources */,
-				BEFC931D1995F0710074C938 /* LGError.m in Sources */,
-				1A1BAD96197A0407008192A7 /* LGVersionComparator.m in Sources */,
-				1A979FE01960BCCC00EE9881 /* LGUnzipper.m in Sources */,
-				BE73CDC719E062AC00441443 /* NSString+cleaned.m in Sources */,
-				BE39FE5319DFBB0100C1B4A1 /* LGDefaults+JSSAddon.m in Sources */,
-				BEE8CF1319E0E7F400981C4B /* NSTextField+setSafeStringValue.m in Sources */,
-				BE77A80019E37C910022B6FB /* NSImage+statusLight.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		1AC6956A195B59EE00D2BD81 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BE025CFF19BAEF8800D36345 /* LGAutoPkgSchedule.m in Sources */,
-				1AC6957B195B59EE00D2BD81 /* AutoPkgrTests.m in Sources */,
-				BE025CF719BAE93400D36345 /* LGAutoPkgTask.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		1A0A86B3195CE6B500A49434 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "mailcore osx";
-			targetProxy = 1A0A86B2195CE6B500A49434 /* PBXContainerItemProxy */;
-		};
-		1AC69573195B59EE00D2BD81 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 1AC6954C195B59ED00D2BD81 /* AutoPkgr */;
-			targetProxy = 1AC69572195B59EE00D2BD81 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin PBXVariantGroup section */
-		1AC69559195B59ED00D2BD81 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				1AC6955A195B59ED00D2BD81 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		1AC6955F195B59EE00D2BD81 /* Credits.rtf */ = {
-			isa = PBXVariantGroup;
-			children = (
-				1AC69560195B59EE00D2BD81 /* en */,
-			);
-			name = Credits.rtf;
-			sourceTree = "<group>";
-		};
-		1AC69565195B59EE00D2BD81 /* MainMenu.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				1AC69566195B59EE00D2BD81 /* Base */,
-			);
-			name = MainMenu.xib;
-			sourceTree = "<group>";
-		};
-		1AC69577195B59EE00D2BD81 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				1AC69578195B59EE00D2BD81 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		BE57AC2C19BA3BBC00BB17B1 /* Localizable.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				BE57AC2B19BA3BBC00BB17B1 /* en */,
-			);
-			name = Localizable.strings;
-			path = ..;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
-/* Begin XCBuildConfiguration section */
-		1AC6957C195B59EE00D2BD81 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx;
-			};
-			name = Debug;
-		};
-		1AC6957D195B59EE00D2BD81 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				SDKROOT = macosx;
-			};
-			name = Release;
-		};
-		1AC6957F195B59EE00D2BD81 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 04CA360328E704A8E80B244B /* Pods-AutoPkgr.debug.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Developer ID Application: The Linde Group Computer Support Inc (JVY2ZR6SEF)";
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AutoPkgr/AutoPkgr-Prefix.pch";
-				INFOPLIST_FILE = "AutoPkgr/AutoPkgr-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				OTHER_CODE_SIGN_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
-			};
-			name = Debug;
-		};
-		1AC69580195B59EE00D2BD81 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 16E87146BB0135D03CB6ECA8 /* Pods-AutoPkgr.release.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Developer ID Application: The Linde Group Computer Support Inc (JVY2ZR6SEF)";
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AutoPkgr/AutoPkgr-Prefix.pch";
-				INFOPLIST_FILE = "AutoPkgr/AutoPkgr-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				OTHER_CODE_SIGN_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
-			};
-			name = Release;
-		};
-		1AC69582195B59EE00D2BD81 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/AutoPkgr.app/Contents/MacOS/AutoPkgr";
-				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AutoPkgr/AutoPkgr-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = "AutoPkgrTests/AutoPkgrTests-Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = Debug;
-		};
-		1AC69583195B59EE00D2BD81 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/AutoPkgr.app/Contents/MacOS/AutoPkgr";
-				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AutoPkgr/AutoPkgr-Prefix.pch";
-				INFOPLIST_FILE = "AutoPkgrTests/AutoPkgrTests-Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		1AC69548195B59ED00D2BD81 /* Build configuration list for PBXProject "AutoPkgr" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				1AC6957C195B59EE00D2BD81 /* Debug */,
-				1AC6957D195B59EE00D2BD81 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		1AC6957E195B59EE00D2BD81 /* Build configuration list for PBXNativeTarget "AutoPkgr" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				1AC6957F195B59EE00D2BD81 /* Debug */,
-				1AC69580195B59EE00D2BD81 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		1AC69581195B59EE00D2BD81 /* Build configuration list for PBXNativeTarget "AutoPkgrTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				1AC69582195B59EE00D2BD81 /* Debug */,
-				1AC69583195B59EE00D2BD81 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = 1AC69545195B59ED00D2BD81 /* Project object */;
-}
+buildNumber=$(git rev-list HEAD | wc -l | tr -d ' ')
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $buildNumber" "${PROJECT_DIR}/${INFOPLIST_FILE}"
+</string>
+		</dict>
+		<key>BEE8CF1119E0E7F400981C4B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>NSTextField+setSafeStringValue.h</string>
+			<key>path</key>
+			<string>Custom Catagories/NSTextField+setSafeStringValue.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BEE8CF1219E0E7F400981C4B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>NSTextField+setSafeStringValue.m</string>
+			<key>path</key>
+			<string>Custom Catagories/NSTextField+setSafeStringValue.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BEE8CF1319E0E7F400981C4B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BEE8CF1219E0E7F400981C4B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BEFC931B1995F0710074C938</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>LGError.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BEFC931C1995F0710074C938</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>LGError.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BEFC931D1995F0710074C938</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BEFC931C1995F0710074C938</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>C97E222596F14727B875BF98</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-AutoPkgr/Pods-AutoPkgr-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>FF435269A548437DA5380201</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods-AutoPkgr.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>1AC69545195B59ED00D2BD81</string>
+</dict>
+</plist>

--- a/AutoPkgr/LGConfigurationWindowController.xib
+++ b/AutoPkgr/LGConfigurationWindowController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6250"/>
@@ -127,24 +127,33 @@
                                                     <rect key="frame" x="297" y="115" width="16" height="16"/>
                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="NSStatusAvailable" id="R1Z-YS-Ixy"/>
                                                 </imageView>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OPb-IV-o9L">
-                                                    <rect key="frame" x="319" y="197" width="122" height="17"/>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OPb-IV-o9L">
+                                                    <rect key="frame" x="319" y="197" width="240" height="17"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="236" id="0ab-0t-FAO"/>
+                                                    </constraints>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Git is not installed." id="c7N-WP-Kn2">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Pbf-A7-T4b">
-                                                    <rect key="frame" x="319" y="156" width="157" height="17"/>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Pbf-A7-T4b">
+                                                    <rect key="frame" x="319" y="156" width="240" height="17"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="236" id="kAb-Y7-tRg"/>
+                                                    </constraints>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="AutoPkg is not installed." id="Jh6-Qb-lwm">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0VQ-id-jlf">
-                                                    <rect key="frame" x="319" y="115" width="212" height="17"/>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0VQ-id-jlf">
+                                                    <rect key="frame" x="319" y="115" width="240" height="17"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="236" id="2HI-ON-OOV"/>
+                                                    </constraints>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="JSS AutoPkg Addon is up to date." id="Y67-Kv-gNs">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -251,9 +260,9 @@
                                                     </scroller>
                                                 </scrollView>
                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c6a-G7-vZU">
-                                                    <rect key="frame" x="15" y="384" width="81" height="17"/>
+                                                    <rect key="frame" x="15" y="384" width="100" height="17"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="77" id="1hG-9y-QAz"/>
+                                                        <constraint firstAttribute="width" constant="96" id="GVr-Rg-452"/>
                                                     </constraints>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Repositories" id="vz5-Q8-aHi">
                                                         <font key="font" metaFont="system"/>
@@ -261,24 +270,27 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OQZ-m7-NDG">
-                                                    <rect key="frame" x="15" y="173" width="52" height="17"/>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OQZ-m7-NDG">
+                                                    <rect key="frame" x="15" y="173" width="100" height="17"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="96" id="YB8-lJ-AMY"/>
+                                                    </constraints>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Recipes" id="0cX-bB-x15">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6E4-OJ-BCm">
-                                                    <rect key="frame" x="15" y="212" width="167" height="17"/>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6E4-OJ-BCm">
+                                                    <rect key="frame" x="15" y="212" width="166" height="17"/>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Add a repo URL manually:" id="1IN-jG-Kev">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PWu-1D-EW1">
-                                                    <rect key="frame" x="188" y="210" width="350" height="22"/>
+                                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PWu-1D-EW1">
+                                                    <rect key="frame" x="186" y="210" width="352" height="22"/>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="https://github.com/autopkg/recipes.git" drawsBackground="YES" id="hVj-tR-yVr">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -373,7 +385,6 @@
                                             <constraints>
                                                 <constraint firstItem="Su6-Sd-cOj" firstAttribute="leading" secondItem="Kzw-up-jZN" secondAttribute="leading" constant="410" id="6vI-Yf-b4J"/>
                                                 <constraint firstAttribute="trailing" secondItem="FaV-GR-28e" secondAttribute="trailing" constant="17" id="7DM-HM-Lmr"/>
-                                                <constraint firstItem="PWu-1D-EW1" firstAttribute="leading" secondItem="6E4-OJ-BCm" secondAttribute="trailing" constant="8" id="9v1-E9-CLu"/>
                                                 <constraint firstItem="FaV-GR-28e" firstAttribute="top" secondItem="8hi-WA-S41" secondAttribute="bottom" constant="5" id="Aze-19-6Fy"/>
                                                 <constraint firstItem="8hi-WA-S41" firstAttribute="leading" secondItem="Kzw-up-jZN" secondAttribute="leading" constant="410" id="Bid-UA-78I"/>
                                                 <constraint firstItem="PWu-1D-EW1" firstAttribute="top" secondItem="9vg-XB-Pqv" secondAttribute="bottom" constant="6" id="Emi-va-fQb"/>
@@ -385,6 +396,7 @@
                                                 <constraint firstItem="8hi-WA-S41" firstAttribute="top" secondItem="mla-ao-F4d" secondAttribute="bottom" constant="18" id="XAk-w1-b9n"/>
                                                 <constraint firstItem="c6a-G7-vZU" firstAttribute="top" secondItem="Kzw-up-jZN" secondAttribute="top" constant="11" id="Xnh-7G-AZY"/>
                                                 <constraint firstAttribute="bottom" secondItem="FaV-GR-28e" secondAttribute="bottom" constant="20" id="YZB-fi-Pdf"/>
+                                                <constraint firstItem="PWu-1D-EW1" firstAttribute="leading" secondItem="6E4-OJ-BCm" secondAttribute="trailing" constant="7" id="dm4-xk-XVh"/>
                                                 <constraint firstItem="OQZ-m7-NDG" firstAttribute="top" secondItem="6E4-OJ-BCm" secondAttribute="bottom" constant="22" id="e9S-Zn-7IQ"/>
                                                 <constraint firstAttribute="trailing" secondItem="mla-ao-F4d" secondAttribute="trailing" constant="17" id="eZF-VL-o2Q"/>
                                                 <constraint firstAttribute="trailing" secondItem="9vg-XB-Pqv" secondAttribute="trailing" constant="17" id="i8a-Gw-IUA"/>
@@ -445,8 +457,11 @@
                                                                     <font key="font" metaFont="system"/>
                                                                 </buttonCell>
                                                             </button>
-                                                            <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="K6Q-1C-fKu">
-                                                                <rect key="frame" x="16" y="26" width="308" height="18"/>
+                                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="K6Q-1C-fKu">
+                                                                <rect key="frame" x="16" y="26" width="340" height="18"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="336" id="gaY-Yi-ukw"/>
+                                                                </constraints>
                                                                 <buttonCell key="cell" type="check" title="Check for repo updates when AutoPkgr starts" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2Rc-4D-cra">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -490,8 +505,8 @@
                                                         <constraint firstItem="K6Q-1C-fKu" firstAttribute="top" secondItem="J8d-qW-trQ" secondAttribute="bottom" constant="14" id="N04-Cg-Gcu"/>
                                                         <constraint firstAttribute="centerX" secondItem="J8d-qW-trQ" secondAttribute="centerX" constant="152.5" id="NT6-d9-dfq"/>
                                                         <constraint firstItem="X02-En-nic" firstAttribute="width" secondItem="7vx-nK-KRd" secondAttribute="width" id="Qug-H3-Tzl"/>
+                                                        <constraint firstAttribute="centerX" secondItem="K6Q-1C-fKu" secondAttribute="centerX" constant="115.5" id="R6j-Jo-W1Q"/>
                                                         <constraint firstItem="oZ2-P7-4IE" firstAttribute="baseline" secondItem="cHq-LH-gnB" secondAttribute="baseline" constant="2" id="SRo-dN-d5C"/>
-                                                        <constraint firstAttribute="centerX" secondItem="K6Q-1C-fKu" secondAttribute="centerX" constant="131.5" id="VsE-pg-HWR"/>
                                                         <constraint firstItem="7vx-nK-KRd" firstAttribute="leading" secondItem="cHq-LH-gnB" secondAttribute="trailing" constant="57" id="gQ7-7z-Jg8"/>
                                                         <constraint firstAttribute="centerY" secondItem="7vx-nK-KRd" secondAttribute="centerY" constant="6.5" id="iB8-QZ-D0M"/>
                                                         <constraint firstItem="cHq-LH-gnB" firstAttribute="leading" secondItem="oZ2-P7-4IE" secondAttribute="trailing" constant="3" id="nqL-2N-Ndj"/>
@@ -517,8 +532,11 @@
                                                                     <font key="font" metaFont="system"/>
                                                                 </buttonCell>
                                                             </button>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RB8-aR-yhY">
-                                                                <rect key="frame" x="129" y="209" width="41" height="17"/>
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RB8-aR-yhY">
+                                                                <rect key="frame" x="16" y="209" width="154" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="150" id="k1R-ZZ-vYM"/>
+                                                                </constraints>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="From:" id="Gzs-A9-nP6">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -537,8 +555,11 @@
                                                                 </connections>
                                                             </textField>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PIX-o6-vdF">
-                                                                <rect key="frame" x="97" y="180" width="73" height="17"/>
-                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Recipients:" id="Vsf-uW-fns">
+                                                                <rect key="frame" x="16" y="180" width="154" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="150" id="Lpc-Vd-h5i"/>
+                                                                </constraints>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Recipients:" id="Vsf-uW-fns">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -555,8 +576,11 @@
                                                                     <outlet property="delegate" destination="-2" id="ww4-Ik-6Ze"/>
                                                                 </connections>
                                                             </tokenField>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cUb-Ex-bej">
-                                                                <rect key="frame" x="86" y="151" width="84" height="17"/>
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cUb-Ex-bej">
+                                                                <rect key="frame" x="16" y="151" width="154" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="150" id="zPP-E2-G5Q"/>
+                                                                </constraints>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="SMTP server:" id="dIA-je-2nB">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -600,15 +624,21 @@
                                                             <progressIndicator hidden="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="6ha-Zn-VKa">
                                                                 <rect key="frame" x="493" y="151" width="16" height="16"/>
                                                             </progressIndicator>
-                                                            <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6N3-g1-fHC">
-                                                                <rect key="frame" x="49" y="108" width="139" height="18"/>
+                                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="6N3-g1-fHC">
+                                                                <rect key="frame" x="49" y="108" width="160" height="18"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="156" id="ZdH-Nl-m5e"/>
+                                                                </constraints>
                                                                 <buttonCell key="cell" type="check" title="Use authentication" bezelStyle="regularSquare" imagePosition="left" inset="2" id="t0c-kT-pxo">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="system"/>
                                                                 </buttonCell>
                                                             </button>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ToE-0q-pH2">
-                                                                <rect key="frame" x="99" y="82" width="71" height="17"/>
+                                                                <rect key="frame" x="16" y="82" width="154" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="150" id="lgz-FQ-qJx"/>
+                                                                </constraints>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="mPh-pa-Wg4">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -626,8 +656,11 @@
                                                                     <outlet property="delegate" destination="-2" id="FbZ-Mk-vPk"/>
                                                                 </connections>
                                                             </textField>
-                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jki-MF-GcS">
-                                                                <rect key="frame" x="104" y="53" width="66" height="17"/>
+                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Jki-MF-GcS">
+                                                                <rect key="frame" x="16" y="53" width="154" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="150" id="91Q-nA-iqT"/>
+                                                                </constraints>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="gMF-3J-P98">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -668,8 +701,11 @@
                                                                     <constraint firstAttribute="width" constant="16" id="Xvu-ms-e1I"/>
                                                                 </constraints>
                                                             </progressIndicator>
-                                                            <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bwp-ds-cik">
-                                                                <rect key="frame" x="170" y="26" width="213" height="18"/>
+                                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="Bwp-ds-cik">
+                                                                <rect key="frame" x="170" y="26" width="240" height="18"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="236" id="owL-rB-dmE"/>
+                                                                </constraints>
                                                                 <buttonCell key="cell" type="check" title="Use Secure Sockets Layer (SSL)" bezelStyle="regularSquare" imagePosition="left" inset="2" id="HLR-S4-ckM">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -686,6 +722,7 @@
                                                         <constraint firstItem="TPC-Gd-b8O" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="37" id="4Fw-Nt-1Ea"/>
                                                         <constraint firstAttribute="trailing" secondItem="zi5-oQ-M5R" secondAttribute="trailing" constant="211" id="4cN-bl-UM7"/>
                                                         <constraint firstItem="cUb-Ex-bej" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="122" id="5a2-yw-ZWJ"/>
+                                                        <constraint firstItem="PIX-o6-vdF" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="16" id="5xG-ul-WpB"/>
                                                         <constraint firstAttribute="trailing" secondItem="uO3-QG-q9R" secondAttribute="trailing" constant="211" id="6ii-5h-AWl"/>
                                                         <constraint firstItem="zi5-oQ-M5R" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="189" id="9sO-hl-yis"/>
                                                         <constraint firstAttribute="trailing" secondItem="T27-XK-VY4" secondAttribute="trailing" constant="21" id="9vn-7o-BUL"/>
@@ -700,30 +737,29 @@
                                                         <constraint firstItem="PIX-o6-vdF" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="93" id="K8I-Kb-kVq"/>
                                                         <constraint firstItem="Bwp-ds-cik" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="170" id="M8g-jq-iXb"/>
                                                         <constraint firstItem="lqq-Vv-857" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="170" id="ODr-Co-ytA"/>
+                                                        <constraint firstItem="RB8-aR-yhY" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="16" id="P9d-5I-6Cg"/>
                                                         <constraint firstAttribute="height" constant="287" id="T1M-st-TO3"/>
                                                         <constraint firstItem="6N3-g1-fHC" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="49" id="V4p-Kj-zlR"/>
                                                         <constraint firstItem="uO3-QG-q9R" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="120" id="WNj-ql-2tJ"/>
-                                                        <constraint firstItem="RB8-aR-yhY" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="129" id="ZOP-4h-vI1"/>
+                                                        <constraint firstItem="Jki-MF-GcS" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="16" id="YxA-TG-4SD"/>
                                                         <constraint firstAttribute="trailing" secondItem="VDb-hs-bB1" secondAttribute="trailing" constant="92" id="aV3-lg-Uhh"/>
                                                         <constraint firstItem="RB8-aR-yhY" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="64" id="ao4-6r-I9W"/>
                                                         <constraint firstItem="6ha-Zn-VKa" firstAttribute="leading" secondItem="HmV-Dc-TUb" secondAttribute="trailing" constant="8" id="bF6-9G-ayD"/>
-                                                        <constraint firstItem="ToE-0q-pH2" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="99" id="bgO-G2-Iic"/>
                                                         <constraint firstItem="SZ2-Hj-GiD" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="219" id="cb0-Vo-wsv"/>
                                                         <constraint firstItem="uO3-QG-q9R" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="170" id="cbK-Hm-MNh"/>
                                                         <constraint firstItem="6N3-g1-fHC" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="166" id="ciK-WG-Lrr"/>
-                                                        <constraint firstItem="PIX-o6-vdF" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="97" id="dN1-eL-GWv"/>
+                                                        <constraint firstItem="cUb-Ex-bej" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="16" id="dru-N2-1Lg"/>
                                                         <constraint firstItem="TPC-Gd-b8O" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="16" id="ewn-YB-Hkm"/>
                                                         <constraint firstAttribute="trailing" secondItem="SZ2-Hj-GiD" secondAttribute="trailing" constant="45" id="eyW-ln-k3G"/>
                                                         <constraint firstItem="0uY-tb-AXy" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="62" id="fPP-Mo-d4J"/>
+                                                        <constraint firstItem="ToE-0q-pH2" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="16" id="iQp-wG-eIg"/>
                                                         <constraint firstItem="zi5-oQ-M5R" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="170" id="lb5-Ts-6NN"/>
-                                                        <constraint firstItem="Jki-MF-GcS" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="104" id="meL-OA-f5F"/>
                                                         <constraint firstItem="HmV-Dc-TUb" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="120" id="n9w-VG-y36"/>
                                                         <constraint firstAttribute="trailing" secondItem="HmV-Dc-TUb" secondAttribute="trailing" constant="116" id="o1H-ee-3cq"/>
                                                         <constraint firstItem="0uY-tb-AXy" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="170" id="oUI-vI-6pa"/>
                                                         <constraint firstItem="T27-XK-VY4" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="222" id="rdh-Lw-e5k"/>
                                                         <constraint firstItem="aRk-NU-9Jl" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="170" id="sRJ-j7-TfI"/>
                                                         <constraint firstItem="aRk-NU-9Jl" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="218" id="tBS-Xf-usg"/>
-                                                        <constraint firstItem="cUb-Ex-bej" firstAttribute="leading" secondItem="0A8-YK-H2P" secondAttribute="leading" constant="86" id="vYF-Ga-W6R"/>
                                                         <constraint firstItem="HmV-Dc-TUb" firstAttribute="leading" secondItem="0MT-rL-IEP" secondAttribute="trailing" constant="8" id="wAW-IH-xWL"/>
                                                         <constraint firstItem="SZ2-Hj-GiD" firstAttribute="leading" secondItem="aRk-NU-9Jl" secondAttribute="trailing" constant="8" id="xaA-Sw-xjU"/>
                                                         <constraint firstItem="Bwp-ds-cik" firstAttribute="top" secondItem="0A8-YK-H2P" secondAttribute="top" constant="248" id="xtK-Zz-lDn"/>
@@ -755,8 +791,11 @@
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8JI-bC-naR">
-                                                                <rect key="frame" x="34" y="84" width="48" height="17"/>
-                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Cache:" id="9Pa-A5-LiR">
+                                                                <rect key="frame" x="12" y="84" width="70" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="66" id="Dbo-6v-hTb"/>
+                                                                </constraints>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Cache:" id="9Pa-A5-LiR">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -800,8 +839,11 @@
                                                                 </connections>
                                                             </button>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RRf-Ty-Jvm">
-                                                                <rect key="frame" x="34" y="54" width="48" height="17"/>
-                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Repos:" id="l5o-py-X9A">
+                                                                <rect key="frame" x="12" y="54" width="70" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="66" id="BJy-Mq-AJY"/>
+                                                                </constraints>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Repos:" id="l5o-py-X9A">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -845,8 +887,11 @@
                                                                 </connections>
                                                             </button>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QvB-k4-dqT">
-                                                                <rect key="frame" x="14" y="24" width="68" height="17"/>
-                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Overrides:" id="g8b-Ua-YZE">
+                                                                <rect key="frame" x="12" y="24" width="70" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="66" id="A7T-bA-ICp"/>
+                                                                </constraints>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Overrides:" id="g8b-Ua-YZE">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -902,21 +947,21 @@
                                                         <constraint firstItem="Qsk-Uz-rho" firstAttribute="top" secondItem="Uu3-dg-Ae2" secondAttribute="top" constant="86" id="9W3-Nw-QeY"/>
                                                         <constraint firstItem="Q6H-Wz-o4m" firstAttribute="top" secondItem="Uu3-dg-Ae2" secondAttribute="top" constant="56" id="CZc-zc-Y7a"/>
                                                         <constraint firstAttribute="trailing" secondItem="Q6H-Wz-o4m" secondAttribute="trailing" constant="150" id="ED9-mx-IlV"/>
-                                                        <constraint firstItem="8JI-bC-naR" firstAttribute="leading" secondItem="Uu3-dg-Ae2" secondAttribute="leading" constant="34" id="EnQ-MC-KxN"/>
                                                         <constraint firstAttribute="height" constant="126" id="Ff8-OO-Oql"/>
                                                         <constraint firstItem="Tl2-iz-Ard" firstAttribute="leading" secondItem="Uu3-dg-Ae2" secondAttribute="leading" constant="85" id="Fmz-fs-FSR"/>
                                                         <constraint firstAttribute="trailing" secondItem="Tl2-iz-Ard" secondAttribute="trailing" constant="244" id="IOw-Ia-Cy3"/>
                                                         <constraint firstAttribute="trailing" secondItem="TYE-36-bIi" secondAttribute="trailing" constant="16" id="JrM-fZ-qP9"/>
                                                         <constraint firstItem="TYE-36-bIi" firstAttribute="top" secondItem="Uu3-dg-Ae2" secondAttribute="top" constant="26" id="KMd-YU-j7v"/>
                                                         <constraint firstItem="KC4-Ks-uGR" firstAttribute="leading" secondItem="Uu3-dg-Ae2" secondAttribute="leading" constant="85" id="M8k-XR-ph3"/>
+                                                        <constraint firstItem="QvB-k4-dqT" firstAttribute="leading" secondItem="Uu3-dg-Ae2" secondAttribute="leading" constant="12" id="SNF-2g-i82"/>
+                                                        <constraint firstItem="8JI-bC-naR" firstAttribute="leading" secondItem="Uu3-dg-Ae2" secondAttribute="leading" constant="12" id="Val-jg-IeM"/>
                                                         <constraint firstAttribute="trailing" secondItem="5lK-cr-mp5" secondAttribute="trailing" constant="16" id="ZE8-DS-Q95"/>
                                                         <constraint firstItem="fAS-2t-NJR" firstAttribute="top" secondItem="Uu3-dg-Ae2" secondAttribute="top" constant="25" id="aa0-Rp-3vO"/>
                                                         <constraint firstAttribute="trailing" secondItem="KC4-Ks-uGR" secondAttribute="trailing" constant="244" id="fQN-r5-0A7"/>
                                                         <constraint firstAttribute="trailing" secondItem="Qsk-Uz-rho" secondAttribute="trailing" constant="150" id="fj6-Ex-pJJ"/>
                                                         <constraint firstAttribute="trailing" secondItem="c0E-Qv-nLs" secondAttribute="trailing" constant="150" id="iev-8A-UGq"/>
                                                         <constraint firstItem="RRf-Ty-Jvm" firstAttribute="top" secondItem="Uu3-dg-Ae2" secondAttribute="top" constant="58" id="ioo-S1-yi1"/>
-                                                        <constraint firstItem="QvB-k4-dqT" firstAttribute="leading" secondItem="Uu3-dg-Ae2" secondAttribute="leading" constant="14" id="nqF-Jr-iRU"/>
-                                                        <constraint firstItem="RRf-Ty-Jvm" firstAttribute="leading" secondItem="Uu3-dg-Ae2" secondAttribute="leading" constant="34" id="pW1-ph-2ek"/>
+                                                        <constraint firstItem="RRf-Ty-Jvm" firstAttribute="leading" secondItem="Uu3-dg-Ae2" secondAttribute="leading" constant="12" id="kgo-7q-zbh"/>
                                                         <constraint firstItem="SPx-dH-wAP" firstAttribute="top" secondItem="Uu3-dg-Ae2" secondAttribute="top" constant="86" id="t3C-sS-NKD"/>
                                                         <constraint firstItem="c0E-Qv-nLs" firstAttribute="top" secondItem="Uu3-dg-Ae2" secondAttribute="top" constant="26" id="zb6-jE-nJl"/>
                                                         <constraint firstItem="Tl2-iz-Ard" firstAttribute="top" secondItem="Uu3-dg-Ae2" secondAttribute="top" constant="55" id="zgB-5p-TN8"/>
@@ -931,8 +976,11 @@
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0gN-B1-Iba">
-                                                                <rect key="frame" x="36" y="24" width="46" height="17"/>
-                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Munki:" id="G9E-uQ-NlG">
+                                                                <rect key="frame" x="12" y="24" width="70" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="66" id="8xk-1T-Fap"/>
+                                                                </constraints>
+                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Munki:" id="G9E-uQ-NlG">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -978,6 +1026,7 @@
                                                         </subviews>
                                                     </view>
                                                     <constraints>
+                                                        <constraint firstItem="0gN-B1-Iba" firstAttribute="leading" secondItem="1dI-Tv-jQl" secondAttribute="leading" constant="12" id="3be-zH-0hM"/>
                                                         <constraint firstItem="ME9-rG-Y8o" firstAttribute="leading" secondItem="1dI-Tv-jQl" secondAttribute="leading" constant="85" id="AST-J9-sQL"/>
                                                         <constraint firstAttribute="trailing" secondItem="ME9-rG-Y8o" secondAttribute="trailing" constant="244" id="Am2-lI-bec"/>
                                                         <constraint firstAttribute="height" constant="66" id="GIn-Ix-8hL"/>
@@ -985,7 +1034,6 @@
                                                         <constraint firstItem="z6I-Bv-EFk" firstAttribute="top" secondItem="1dI-Tv-jQl" secondAttribute="top" constant="26" id="QVU-gi-kTc"/>
                                                         <constraint firstItem="ME9-rG-Y8o" firstAttribute="top" secondItem="1dI-Tv-jQl" secondAttribute="top" constant="25" id="RHV-hP-Mmq"/>
                                                         <constraint firstItem="0gN-B1-Iba" firstAttribute="top" secondItem="1dI-Tv-jQl" secondAttribute="top" constant="28" id="Vcc-DL-5QU"/>
-                                                        <constraint firstItem="0gN-B1-Iba" firstAttribute="leading" secondItem="1dI-Tv-jQl" secondAttribute="leading" constant="36" id="bWz-6M-siB"/>
                                                         <constraint firstAttribute="trailing" secondItem="z6I-Bv-EFk" secondAttribute="trailing" constant="15" id="dcf-Me-MaJ"/>
                                                         <constraint firstAttribute="trailing" secondItem="j1S-cB-b4Q" secondAttribute="trailing" constant="149" id="eke-Tt-CAB"/>
                                                     </constraints>
@@ -1063,7 +1111,10 @@
                                                                 </connections>
                                                             </textField>
                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IMP-Hl-JTs">
-                                                                <rect key="frame" x="18" y="144" width="64" height="17"/>
+                                                                <rect key="frame" x="12" y="144" width="70" height="17"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="66" id="uYF-Wa-ZgV"/>
+                                                                </constraints>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="JSS URL:" id="jPs-xw-PK5">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1148,7 +1199,7 @@
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="62" id="0fR-i2-HQp"/>
                                                                 </constraints>
-                                                                <buttonCell key="cell" type="roundRect" title="Connect" bezelStyle="roundedRect" image="6250C4AB-B6B8-4E93-9665-281B153F2368" imagePosition="overlaps" alignment="center" borderStyle="border" inset="2" id="4W3-PH-h0C">
+                                                                <buttonCell key="cell" type="roundRect" title="Connect" bezelStyle="roundedRect" image="2B165DDA-C7F9-40F2-9A92-47A3172A7A6D" imagePosition="overlaps" alignment="center" borderStyle="border" inset="2" id="4W3-PH-h0C">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                     <font key="font" metaFont="cellTitle"/>
                                                                 </buttonCell>
@@ -1160,6 +1211,7 @@
                                                     </view>
                                                     <constraints>
                                                         <constraint firstItem="pyb-Pf-WKJ" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="60" id="0jG-AI-6ZF"/>
+                                                        <constraint firstItem="IMP-Hl-JTs" firstAttribute="leading" secondItem="QM0-hF-4j5" secondAttribute="leading" constant="12" id="4FZ-fs-iPi"/>
                                                         <constraint firstItem="TfY-fp-ztg" firstAttribute="leading" secondItem="QM0-hF-4j5" secondAttribute="leading" constant="16" id="4ku-ve-NVr"/>
                                                         <constraint firstItem="6MF-CB-ccc" firstAttribute="centerY" secondItem="gcn-rW-umQ" secondAttribute="centerY" constant="0.5" id="503-vV-Cyg"/>
                                                         <constraint firstItem="9lJ-vz-FvC" firstAttribute="leading" secondItem="pyb-Pf-WKJ" secondAttribute="trailing" constant="8" id="7h1-aI-yoO"/>
@@ -1167,7 +1219,6 @@
                                                         <constraint firstItem="6MF-CB-ccc" firstAttribute="centerX" secondItem="gcn-rW-umQ" secondAttribute="centerX" id="9L9-PL-qgo"/>
                                                         <constraint firstAttribute="trailing" secondItem="TfY-fp-ztg" secondAttribute="trailing" constant="16" id="HPS-IG-9Ox"/>
                                                         <constraint firstItem="LS6-bP-hJx" firstAttribute="leading" secondItem="9lJ-vz-FvC" secondAttribute="trailing" constant="8" id="J46-UT-wQe"/>
-                                                        <constraint firstItem="IMP-Hl-JTs" firstAttribute="leading" secondItem="QM0-hF-4j5" secondAttribute="leading" constant="18" id="LVa-Ya-gUL"/>
                                                         <constraint firstItem="6MF-CB-ccc" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="30" id="P1I-fY-SbK"/>
                                                         <constraint firstAttribute="trailing" secondItem="6MF-CB-ccc" secondAttribute="trailing" constant="15" id="QTU-cf-dMe"/>
                                                         <constraint firstItem="6Ki-wr-8K2" firstAttribute="leading" secondItem="uZo-nq-Njx" secondAttribute="trailing" constant="8" id="VNX-lr-Qoo"/>
@@ -1317,7 +1368,7 @@ Gw
         </customObject>
     </objects>
     <resources>
-        <image name="6250C4AB-B6B8-4E93-9665-281B153F2368" width="1" height="1">
+        <image name="2B165DDA-C7F9-40F2-9A92-47A3172A7A6D" width="1" height="1">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPj9YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
 GR4fIyQsLzI4O1UkbnVsbNUJCgsMDQ4PEBESVk5TU2l6ZVYkY2xhc3NcTlNJbWFnZUZsYWdzVk5TUmVw

--- a/Podfile
+++ b/Podfile
@@ -11,4 +11,9 @@ pod 'AHProxySettings'
 end
 
 target "AutoPkgrTests" do
+pod 'Sparkle', '~> 1.8'
+pod 'SSKeychain', '~> 1.2'
+pod 'AFNetworking', '~> 2.4.1'
+pod 'XMLDictionary', '~> 1.4'
+pod 'AHProxySettings'
 end


### PR DESCRIPTION
Made constraints a fixed width and resolved text alignment issues. This
should help text in the GUI display more consistently between 10.9
(which uses Lucida Grande) and 10.10 (which uses Helvetica).

Also updated the podfile with AutoPkgrTests targets to resolve a build
issue.
