### PR TITLE
Always include @sheagcraigs jss repos to popular repos list.

### DIFF
--- a/AutoPkgr/LGConstants.h
+++ b/AutoPkgr/LGConstants.h
@@ -41,6 +41,7 @@ extern NSString *const kLGGitMLReleasesJSONURL;
 extern NSString *const kLGJSSAddonJSONURL;
 extern NSString *const kLGAutoPkgDownloadURL;
 extern NSString *const kLGAutoPkgRepositoriesJSONURL;
+extern NSString *const kLGJSSDefaultRepo;
 
 #pragma mark - Defaults
 extern NSString *const kLGSMTPServer;

--- a/AutoPkgr/LGConstants.m
+++ b/AutoPkgr/LGConstants.m
@@ -45,6 +45,8 @@ NSString *const kLGJSSAddonJSONURL = @"https://api.github.com/repos/sheagcraig/j
 
 NSString *const kLGAutoPkgDownloadURL = @"https://github.com/autopkg/autopkg/zipball/master";
 NSString *const kLGAutoPkgRepositoriesJSONURL = @"https://api.github.com/orgs/autopkg/repos?per_page=100";
+NSString *const kLGJSSDefaultRepo = @"https://github.com/sheagcraig/jss-recipes.git";
+
 
 #pragma mark - Defaults
 NSString *const kLGSMTPServer = @"SMTPServer";

--- a/AutoPkgr/LGJSSAddon.m
+++ b/AutoPkgr/LGJSSAddon.m
@@ -28,7 +28,6 @@
 #import "LGAutoPkgTask.h"
 
 #pragma mark - Class constants
-NSString *defaultJSSRepo = @"https://github.com/sheagcraig/jss-recipes.git";
 
 @implementation LGJSSAddon {
     LGDefaults *_defaults;
@@ -131,10 +130,10 @@ NSString *defaultJSSRepo = @"https://github.com/sheagcraig/jss-recipes.git";
     [installer installJSSAddon:^(NSError *error) {
         BOOL success = (error == nil);
         if (success) {
-            NSString *message = [NSString stringWithFormat:@"Adding %@",defaultJSSRepo];
-            NSLog(@"Adding default JSS recipe repository: %@", defaultJSSRepo);
+            NSString *message = [NSString stringWithFormat:@"Adding %@",kLGJSSDefaultRepo];
+            NSLog(@"Adding default JSS recipe repository: %@", kLGJSSDefaultRepo);
             [_progressDelegate startProgressWithMessage:message];
-            [LGAutoPkgTask repoAdd:defaultJSSRepo reply:^(NSError *error) {
+            [LGAutoPkgTask repoAdd:kLGJSSDefaultRepo reply:^(NSError *error) {
                 [_progressDelegate stopProgress:error];
                 [[NSNotificationCenter defaultCenter] postNotificationName:kLGNotificationReposModified
                                                                     object:nil];

--- a/AutoPkgr/LGPopularRepositories.h
+++ b/AutoPkgr/LGPopularRepositories.h
@@ -27,7 +27,6 @@
 
 @interface LGPopularRepositories : NSObject <NSApplicationDelegate, NSTableViewDelegate, NSTableViewDataSource> {
 
-    NSArray *_recipeRepos;
     NSArray *_popularRepos;
     NSArray *_activeRepos;
     NSArray *_searchedRepos;

--- a/AutoPkgr/LGPopularRepositories.m
+++ b/AutoPkgr/LGPopularRepositories.m
@@ -30,13 +30,12 @@
 
     if (self) {
         _awake = NO;
-
         _jsonLoader = [[LGGitHubJSONLoader alloc] init];
 
-        _recipeRepos = [_jsonLoader getAutoPkgRecipeRepos];
+        NSArray *recipeRepos = [_jsonLoader getAutoPkgRecipeRepos];
 
-        if (_recipeRepos != nil) {
-            _popularRepos = _recipeRepos;
+        if (recipeRepos != nil) {
+            _popularRepos = [recipeRepos arrayByAddingObject:kLGJSSDefaultRepo];
         } else {
             _popularRepos = @[ @"https://github.com/autopkg/recipes.git",
                                @"https://github.com/autopkg/keeleysam-recipes.git",
@@ -62,7 +61,8 @@
                                @"https://github.com/autopkg/justinrummel-recipes.git",
                                @"https://github.com/autopkg/n8felton-recipes.git",
                                @"https://github.com/autopkg/groob-recipes.git",
-                               @"https://github.com/autopkg/jazzace-recipes.git" ];
+                               @"https://github.com/autopkg/jazzace-recipes.git",
+                               kLGJSSDefaultRepo];
         }
 
         [self assembleRepos];


### PR DESCRIPTION
This is minimal, due to a number of other related changes in the 1.2-alpha branch.  I'll put a more robust feature into that release, that will either only add the repo to the list if jss-autopkg-addon is installed. Or perhaps better yet, if a .jss Recipe is selected and the add-on is not installed, it will prompt for installation.

Addresses #204 
