### PR TITLE
Minor adjustments to how proxy password is encoded

### DIFF
--- a/AutoPkgr/LGAutoPkgTask.m
+++ b/AutoPkgr/LGAutoPkgTask.m
@@ -253,9 +253,10 @@ NSString *autopkg()
 
         LGDefaults *defaults = [[LGDefaults alloc] init];
 
-        if ([defaults objectForKey:@"useSystemProxies"]) {
+        if ([defaults boolForKey:@"useSystemProxies"]) {
             AHProxySettings *settings = [[AHProxySettings alloc] initWithDestination:@"https://github.com"];
             if (settings.taskDictionary) {
+                DLog(@"Using System Proxies: %@",settings.taskDictionary);
                 // This will just initialize the _internalEnvironment
                 [self addEnvironmentVariable:nil forKey:nil];
                 [_internalEnvironment addEntriesFromDictionary:settings.taskDictionary];

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ pod 'Sparkle', '~> 1.8'
 pod 'SSKeychain', '~> 1.2'
 pod 'AFNetworking', '~> 2.4.1'
 pod 'XMLDictionary', '~> 1.4'
-pod 'AHProxySettings'
+pod 'AHProxySettings', '~> 0.1.1'
 end
 
 target "AutoPkgrTests" do
@@ -15,5 +15,5 @@ pod 'Sparkle', '~> 1.8'
 pod 'SSKeychain', '~> 1.2'
 pod 'AFNetworking', '~> 2.4.1'
 pod 'XMLDictionary', '~> 1.4'
-pod 'AHProxySettings'
+pod 'AHProxySettings', '~> 0.1.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,21 +17,21 @@ PODS:
   - AFNetworking/Reachability (2.4.1)
   - AFNetworking/Security (2.4.1)
   - AFNetworking/Serialization (2.4.1)
-  - AHProxySettings (0.1)
+  - AHProxySettings (0.1.1)
   - Sparkle (1.8.0)
   - SSKeychain (1.2.2)
   - XMLDictionary (1.4)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.4.1)
-  - AHProxySettings
+  - AHProxySettings (~> 0.1.1)
   - Sparkle (~> 1.8)
   - SSKeychain (~> 1.2)
   - XMLDictionary (~> 1.4)
 
 SPEC CHECKSUMS:
   AFNetworking: 0aabc6fae66d6e5d039eeb21c315843c7aae51ab
-  AHProxySettings: c2c5a19614bd74d0aaa2ff0529330236cb54d2c3
+  AHProxySettings: 9237c332cf97cdd5c916b0203bbe19866ad4a615
   Sparkle: 5eb20bb37ca21e471dab8417dee880198d905327
   SSKeychain: cc48bd3ad24fcd9125adb9e0d23dd50b8bbd08b9
   XMLDictionary: 735e81b9a043e220b0d24e9d4f16719606f2e0fc


### PR DESCRIPTION
[Update proxy lib](https://github.com/eahrold/AHProxySettings/commit/ac09acc27e2f38c6079081a5d5bd151c6ebb0b46) to resolve an over encoding of characters during url encoding.
Also Use boolForKey not objectForKey when checking useSystemProxies default.
