### PR TITLE
Redesign for JDS type in JSS_REPO entry

### DIFF
--- a/AutoPkgr.xcodeproj/project.pbxproj
+++ b/AutoPkgr.xcodeproj/project.pbxproj
@@ -55,6 +55,9 @@
 		BE1C810419E8224000EF77F3 /* NSImage+statusLight.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1C810219E8224000EF77F3 /* NSImage+statusLight.m */; };
 		BE32178B19ED9ACA00A92E5A /* LGRecipeOverrides.m in Sources */ = {isa = PBXBuildFile; fileRef = BE32178A19ED9ACA00A92E5A /* LGRecipeOverrides.m */; };
 		BE57AC2A19BA3BBC00BB17B1 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BE57AC2C19BA3BBC00BB17B1 /* Localizable.strings */; };
+		BE67E8751A44E10500484151 /* LGRecipeSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = BE67E8731A44E10500484151 /* LGRecipeSearch.m */; };
+		BE67E8761A44E10500484151 /* LGRecipeSearchPanel.xib in Resources */ = {isa = PBXBuildFile; fileRef = BE67E8741A44E10500484151 /* LGRecipeSearchPanel.xib */; };
+		BE67E8771A44F02B00484151 /* LGRecipeSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = BE67E8731A44E10500484151 /* LGRecipeSearch.m */; };
 		BE6815D51A0B18DE004AD310 /* LGUserNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = BE6815D41A0B18DE004AD310 /* LGUserNotifications.m */; };
 		BE73CDC719E062AC00441443 /* NSString+cleaned.m in Sources */ = {isa = PBXBuildFile; fileRef = BE73CDC619E062AC00441443 /* NSString+cleaned.m */; };
 		BE8526B219D5F641007DFA9E /* SecurityInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE8526B119D5F641007DFA9E /* SecurityInterface.framework */; };
@@ -278,6 +281,9 @@
 		BE57733619D519E400D872A4 /* LGJSSImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGJSSImporter.h; sourceTree = "<group>"; };
 		BE57733719D519E400D872A4 /* LGJSSImporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGJSSImporter.m; sourceTree = "<group>"; };
 		BE57AC2B19BA3BBC00BB17B1 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		BE67E8721A44E10500484151 /* LGRecipeSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGRecipeSearch.h; sourceTree = "<group>"; };
+		BE67E8731A44E10500484151 /* LGRecipeSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGRecipeSearch.m; sourceTree = "<group>"; };
+		BE67E8741A44E10500484151 /* LGRecipeSearchPanel.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LGRecipeSearchPanel.xib; sourceTree = "<group>"; };
 		BE6815D31A0B18DE004AD310 /* LGUserNotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGUserNotifications.h; sourceTree = "<group>"; };
 		BE6815D41A0B18DE004AD310 /* LGUserNotifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGUserNotifications.m; sourceTree = "<group>"; };
 		BE73CDC519E062AC00441443 /* NSString+cleaned.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+cleaned.h"; path = "Custom Catagories/NSString+cleaned.h"; sourceTree = "<group>"; };
@@ -425,6 +431,7 @@
 				1AC69565195B59EE00D2BD81 /* MainMenu.xib */,
 				1AC9841E195CEC360071CAB3 /* LGConfigurationWindowController.xib */,
 				BE0BACD01A2560AE00554989 /* LGJSSDistributionPointsPrefPanel.xib */,
+				BE67E8741A44E10500484151 /* LGRecipeSearchPanel.xib */,
 				1AC69568195B59EE00D2BD81 /* Images.xcassets */,
 				1AC98423195DF6270071CAB3 /* Resources */,
 				1AC69557195B59ED00D2BD81 /* Supporting Files */,
@@ -572,6 +579,8 @@
 				BE32178A19ED9ACA00A92E5A /* LGRecipeOverrides.m */,
 				BE32178C19EDA15400A92E5A /* LGTableView.h */,
 				BE32178D19EDA15400A92E5A /* LGTableView.m */,
+				BE67E8721A44E10500484151 /* LGRecipeSearch.h */,
+				BE67E8731A44E10500484151 /* LGRecipeSearch.m */,
 				BE57733619D519E400D872A4 /* LGJSSImporter.h */,
 				BE57733719D519E400D872A4 /* LGJSSImporter.m */,
 				BE0BACCE1A2560AE00554989 /* LGJSSDistributionPointsPrefPanel.h */,
@@ -774,6 +783,7 @@
 				1A2C7FAE19CC9F8300CFF472 /* codesign.py in Resources */,
 				1AC98420195CEC360071CAB3 /* LGConfigurationWindowController.xib in Resources */,
 				BE0BACD21A2560AE00554989 /* LGJSSDistributionPointsPrefPanel.xib in Resources */,
+				BE67E8761A44E10500484151 /* LGRecipeSearchPanel.xib in Resources */,
 				BE57AC2A19BA3BBC00BB17B1 /* Localizable.strings in Resources */,
 				1AC98427195DF6350071CAB3 /* autopkgr.png in Resources */,
 				1AC69561195B59EE00D2BD81 /* Credits.rtf in Resources */,
@@ -954,6 +964,7 @@
 				BE05CE8219DAF6320089068B /* LGAutoPkgrAuthorizer.m in Sources */,
 				BE05CE8319DAF6320089068B /* LGAutoPkgrHelperConnection.m in Sources */,
 				BE73CDC719E062AC00441443 /* NSString+cleaned.m in Sources */,
+				BE67E8751A44E10500484151 /* LGRecipeSearch.m in Sources */,
 				BED297611A3F975000511CD7 /* LGDefaults+JSSImporter.m in Sources */,
 				BEE8CF1319E0E7F400981C4B /* NSTextField+setSafeStringValue.m in Sources */,
 				BE1C810319E8224000EF77F3 /* NSImage+statusLight.m in Sources */,
@@ -970,6 +981,7 @@
 				BEFC3C791A3DF16700C789E9 /* LGTestPort.m in Sources */,
 				BEFC3C7C1A3DF16700C789E9 /* LGPopularRepositories.m in Sources */,
 				BEFC3C7D1A3DF16700C789E9 /* LGRecipes.m in Sources */,
+				BE67E8771A44F02B00484151 /* LGRecipeSearch.m in Sources */,
 				BEFC3C7E1A3DF16700C789E9 /* LGRecipeOverrides.m in Sources */,
 				BEFC3C7F1A3DF16700C789E9 /* LGTableView.m in Sources */,
 				BEFC3C821A3DF16700C789E9 /* LGConstants.m in Sources */,

--- a/AutoPkgr/LGAppDelegate.m
+++ b/AutoPkgr/LGAppDelegate.m
@@ -199,8 +199,6 @@
 - (IBAction)uninstallHelper:(id)sender
 {
     LGAutoPkgrHelperConnection *helper = [LGAutoPkgrHelperConnection new];
-    LGDefaults *defaults = [[LGDefaults alloc] init];
-
     NSData *authData = [LGAutoPkgrAuthorizer authorizeHelper];
 
     [helper connectToHelper];
@@ -215,7 +213,6 @@
                 }];
             } else {
                 // if uninstalling turn off schedule in defaults so it's not automatically recreated
-                defaults.checkForNewVersionsOfAppsAutomaticallyEnabled = NO;
                 NSAlert *alert = [NSAlert alertWithMessageText:@"Removed AutoPkgr associated files" defaultButton:@"Thanks for using AutoPkgr" alternateButton:nil otherButton:nil informativeTextWithFormat: @"including the helper tool, launchd schedule, and other launchd plist. You can safely remove it from your Applications folder."];
                 [alert runModal];
                 [[NSApplication sharedApplication]terminate:self];

--- a/AutoPkgr/LGAutoPkgTask.m
+++ b/AutoPkgr/LGAutoPkgTask.m
@@ -30,9 +30,9 @@ NSString *const kLGAutoPkgRecipeNameKey = @"Name";
 NSString *const kLGAutoPkgRecipeIdentifierKey = @"Identifier";
 NSString *const kLGAutoPkgRecipeParentKey = @"ParentRecipe";
 NSString *const kLGAutoPkgRecipePathKey = @"Path";
-NSString *const kLGAutoPkgRepoNameKey = @"repo_name";
-NSString *const kLGAutoPkgRepoPathKey = @"repo_path";
-NSString *const kLGAutoPkgRepoURLKey = @"repo_url";
+NSString *const kLGAutoPkgRepoNameKey = @"RepoName";
+NSString *const kLGAutoPkgRepoPathKey = @"RepoPath";
+NSString *const kLGAutoPkgRepoURLKey = @"RepoURL";
 
 // This is a function so in the future this could be configured to
 // determine autopkg path in a more robust way.
@@ -656,7 +656,7 @@ typedef void (^AutoPkgReplyErrorBlock)(NSError *error);
                             }
                             [searchResults addObject:@{kLGAutoPkgRecipeNameKey:[recipe stringByDeletingPathExtension],
                                                        kLGAutoPkgRepoNameKey:repo,
-                                                       kLGAutoPkgRepoPathKey:path,
+                                                       kLGAutoPkgRecipePathKey:path,
                                                        }];
                         }
                     }

--- a/AutoPkgr/LGConfigurationWindowController.h
+++ b/AutoPkgr/LGConfigurationWindowController.h
@@ -43,7 +43,6 @@
 // Checkboxes
 @property (weak) IBOutlet NSButton *smtpAuthenticationEnabledButton;
 @property (weak) IBOutlet NSButton *smtpTLSEnabledButton;
-@property (weak) IBOutlet NSButton *warnBeforeQuittingButton;
 @property (weak) IBOutlet NSButton *checkForNewVersionsOfAppsAutomaticallyButton;
 @property (weak) IBOutlet NSButton *checkForRepoUpdatesAutomaticallyButton;
 @property (weak) IBOutlet NSButton *sendEmailNotificationsWhenNewVersionsAreFoundButton;

--- a/AutoPkgr/LGConfigurationWindowController.m
+++ b/AutoPkgr/LGConfigurationWindowController.m
@@ -68,6 +68,9 @@
 
     // -- Set up the IBOutlets -- //
 
+    // Modal Windows
+    _popRepoTableViewHandler.modalWindow = self.window;
+
     // AutoPkg settings
     _localMunkiRepo.safeStringValue = _defaults.munkiRepo;
     _autoPkgCacheDir.safeStringValue = _defaults.autoPkgCacheDir;

--- a/AutoPkgr/LGConfigurationWindowController.xib
+++ b/AutoPkgr/LGConfigurationWindowController.xib
@@ -47,7 +47,6 @@
                 <outlet property="testSmtpServerSpinner" destination="6ha-Zn-VKa" id="gnY-fl-miO"/>
                 <outlet property="testSmtpServerStatus" destination="VDb-hs-bB1" id="jIN-1C-wZW"/>
                 <outlet property="updateRepoNowButton" destination="X02-En-nic" id="yZU-6m-VPk"/>
-                <outlet property="warnBeforeQuittingButton" destination="KMe-Rd-d2t" id="28W-Xr-e8Z"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>
         </customObject>
@@ -160,16 +159,6 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <button translatesAutoresizingMaskIntoConstraints="NO" id="KMe-Rd-d2t">
-                                                    <rect key="frame" x="198" y="21" width="215" height="18"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="211" id="ily-V7-o6E"/>
-                                                    </constraints>
-                                                    <buttonCell key="cell" type="check" title="Warn before quitting AutoPkgr" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="SHW-TF-Y2L">
-                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                        <font key="font" metaFont="system"/>
-                                                    </buttonCell>
-                                                </button>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="x1S-bd-tl3" firstAttribute="width" secondItem="ClY-1a-e2c" secondAttribute="width" id="0Rl-Lx-Jc3"/>
@@ -190,12 +179,10 @@
                                                 <constraint firstItem="f8q-xY-QUg" firstAttribute="leading" secondItem="x1S-bd-tl3" secondAttribute="trailing" constant="8" id="cra-8T-RjN"/>
                                                 <constraint firstAttribute="centerX" secondItem="ClY-1a-e2c" secondAttribute="centerX" constant="116.5" id="g7p-PG-fiZ"/>
                                                 <constraint firstItem="Pbf-A7-T4b" firstAttribute="leading" secondItem="f8q-xY-QUg" secondAttribute="trailing" constant="8" id="jqJ-1g-M7m"/>
-                                                <constraint firstAttribute="centerX" secondItem="KMe-Rd-d2t" secondAttribute="centerX" constant="3" id="kEh-Sa-lcW"/>
                                                 <constraint firstAttribute="centerY" secondItem="kGA-EW-Dsj" secondAttribute="centerY" constant="-83" id="keY-ao-C57"/>
                                                 <constraint firstItem="KkE-qM-Hy6" firstAttribute="leading" secondItem="ClY-1a-e2c" secondAttribute="trailing" constant="8" id="oHr-K9-shF"/>
                                                 <constraint firstAttribute="centerY" secondItem="f8q-xY-QUg" secondAttribute="centerY" constant="-42" id="poa-PN-pTo"/>
                                                 <constraint firstAttribute="centerY" secondItem="Pbf-A7-T4b" secondAttribute="centerY" constant="-41.5" id="sK0-IT-bXJ"/>
-                                                <constraint firstAttribute="bottom" secondItem="KMe-Rd-d2t" secondAttribute="bottom" constant="23" id="yEb-cc-gm2"/>
                                                 <constraint firstItem="uPW-I4-WKp" firstAttribute="width" secondItem="x1S-bd-tl3" secondAttribute="width" id="yyb-LM-xIe"/>
                                             </constraints>
                                         </view>
@@ -1289,10 +1276,7 @@
                                                                 </tableHeaderView>
                                                             </scrollView>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bP2-yc-Y9I">
-                                                                <rect key="frame" x="66" y="8" width="158" height="28"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" constant="148" id="DkS-c1-cKo"/>
-                                                                </constraints>
+                                                                <rect key="frame" x="23" y="8" width="145" height="28"/>
                                                                 <buttonCell key="cell" type="push" title="Add Distribution Point" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="c7k-eo-8gx">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1302,9 +1286,9 @@
                                                                 </connections>
                                                             </button>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7Lj-Se-MNx">
-                                                                <rect key="frame" x="222" y="8" width="158" height="28"/>
+                                                                <rect key="frame" x="173" y="8" width="140" height="28"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" constant="148" id="waM-NM-J3j"/>
+                                                                    <constraint firstAttribute="width" constant="130" id="Kvr-9c-xzX"/>
                                                                 </constraints>
                                                                 <buttonCell key="cell" type="push" title="Edit Selected" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="so1-eQ-Gsw">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1315,9 +1299,9 @@
                                                                 </connections>
                                                             </button>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3nm-a0-5bT">
-                                                                <rect key="frame" x="378" y="8" width="158" height="28"/>
+                                                                <rect key="frame" x="316" y="8" width="141" height="28"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" constant="148" id="vJx-4Y-tX3"/>
+                                                                    <constraint firstAttribute="width" constant="131" id="btF-3n-m0p"/>
                                                                 </constraints>
                                                                 <buttonCell key="cell" type="push" title="Remove Selected" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="z6x-VY-deB">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1327,37 +1311,49 @@
                                                                     <action selector="removeDistributionPoint:" target="0iG-YL-fA3" id="y8h-Vq-nDx"/>
                                                                 </connections>
                                                             </button>
+                                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="lpc-x9-S3q">
+                                                                <rect key="frame" x="469" y="14" width="116" height="18"/>
+                                                                <buttonCell key="cell" type="check" title="Use Master JDS" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="x9m-4x-ZIz">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="enableMasterJDS:" target="0iG-YL-fA3" id="LJm-Xd-XfA"/>
+                                                                </connections>
+                                                            </button>
                                                         </subviews>
                                                     </view>
                                                     <constraints>
                                                         <constraint firstItem="pyb-Pf-WKJ" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="60" id="0jG-AI-6ZF"/>
+                                                        <constraint firstItem="bP2-yc-Y9I" firstAttribute="baseline" secondItem="7Lj-Se-MNx" secondAttribute="baseline" id="1Kz-gL-fD9"/>
                                                         <constraint firstItem="TfY-fp-ztg" firstAttribute="leading" secondItem="QM0-hF-4j5" secondAttribute="leading" constant="16" id="4ku-ve-NVr"/>
                                                         <constraint firstItem="6MF-CB-ccc" firstAttribute="centerY" secondItem="gcn-rW-umQ" secondAttribute="centerY" constant="0.5" id="503-vV-Cyg"/>
-                                                        <constraint firstAttribute="bottom" secondItem="7Lj-Se-MNx" secondAttribute="bottom" constant="11" id="5Vt-D0-fFr"/>
                                                         <constraint firstItem="9lJ-vz-FvC" firstAttribute="leading" secondItem="pyb-Pf-WKJ" secondAttribute="trailing" constant="8" id="7h1-aI-yoO"/>
                                                         <constraint firstItem="IMP-Hl-JTs" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="28" id="8rz-qn-7yK"/>
                                                         <constraint firstItem="6MF-CB-ccc" firstAttribute="centerX" secondItem="gcn-rW-umQ" secondAttribute="centerX" id="9L9-PL-qgo"/>
+                                                        <constraint firstItem="3nm-a0-5bT" firstAttribute="leading" secondItem="7Lj-Se-MNx" secondAttribute="trailing" constant="13" id="FLY-hA-eqb"/>
+                                                        <constraint firstItem="lpc-x9-S3q" firstAttribute="leading" secondItem="3nm-a0-5bT" secondAttribute="trailing" constant="19" id="Gdl-GQ-qgV"/>
                                                         <constraint firstAttribute="trailing" secondItem="TfY-fp-ztg" secondAttribute="trailing" constant="16" id="HPS-IG-9Ox"/>
                                                         <constraint firstItem="LS6-bP-hJx" firstAttribute="leading" secondItem="9lJ-vz-FvC" secondAttribute="trailing" constant="8" id="J46-UT-wQe"/>
-                                                        <constraint firstAttribute="bottom" secondItem="bP2-yc-Y9I" secondAttribute="bottom" constant="11" id="Lbe-jN-IPU"/>
+                                                        <constraint firstItem="7Lj-Se-MNx" firstAttribute="baseline" secondItem="3nm-a0-5bT" secondAttribute="baseline" id="Kvj-cI-GJC"/>
                                                         <constraint firstItem="6MF-CB-ccc" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="30" id="P1I-fY-SbK"/>
+                                                        <constraint firstItem="3nm-a0-5bT" firstAttribute="top" secondItem="TfY-fp-ztg" secondAttribute="bottom" constant="8" symbolic="YES" id="PxJ-Hn-7zQ"/>
                                                         <constraint firstAttribute="trailing" secondItem="6MF-CB-ccc" secondAttribute="trailing" constant="15" id="QTU-cf-dMe"/>
                                                         <constraint firstItem="6Ki-wr-8K2" firstAttribute="leading" secondItem="uZo-nq-Njx" secondAttribute="trailing" constant="8" id="VNX-lr-Qoo"/>
+                                                        <constraint firstAttribute="trailing" secondItem="3nm-a0-5bT" secondAttribute="trailing" constant="149" id="VtO-oA-eEx"/>
                                                         <constraint firstItem="9lJ-vz-FvC" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="57" id="WOy-in-uw7"/>
                                                         <constraint firstItem="6Ki-wr-8K2" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="57" id="X09-lu-Gft"/>
-                                                        <constraint firstItem="7Lj-Se-MNx" firstAttribute="centerX" secondItem="TfY-fp-ztg" secondAttribute="centerX" constant="-0.5" id="Y6L-EN-I30"/>
                                                         <constraint firstItem="pyb-Pf-WKJ" firstAttribute="leading" secondItem="6Ki-wr-8K2" secondAttribute="trailing" constant="13" id="Yca-Kc-O0c"/>
+                                                        <constraint firstAttribute="bottom" secondItem="TfY-fp-ztg" secondAttribute="bottom" constant="37" id="YeR-ig-ezZ"/>
                                                         <constraint firstItem="uZo-nq-Njx" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="60" id="Yjx-7L-oYO"/>
                                                         <constraint firstItem="IMP-Hl-JTs" firstAttribute="leading" secondItem="QM0-hF-4j5" secondAttribute="leading" constant="10" id="a2A-bm-qdl"/>
-                                                        <constraint firstAttribute="bottom" secondItem="3nm-a0-5bT" secondAttribute="bottom" constant="11" id="aOs-wR-cqi"/>
-                                                        <constraint firstItem="3nm-a0-5bT" firstAttribute="leading" secondItem="7Lj-Se-MNx" secondAttribute="trailing" constant="8" id="buK-Xh-QCy"/>
                                                         <constraint firstItem="mbd-An-9Bi" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="25" id="ewu-SR-ETx"/>
-                                                        <constraint firstItem="7Lj-Se-MNx" firstAttribute="leading" secondItem="bP2-yc-Y9I" secondAttribute="trailing" constant="8" id="jdu-mL-7sz"/>
+                                                        <constraint firstItem="3nm-a0-5bT" firstAttribute="centerY" secondItem="lpc-x9-S3q" secondAttribute="centerY" id="gmz-5K-3gS"/>
                                                         <constraint firstAttribute="trailing" secondItem="mbd-An-9Bi" secondAttribute="trailing" constant="40" id="l5V-Wi-Ch5"/>
+                                                        <constraint firstItem="7Lj-Se-MNx" firstAttribute="leading" secondItem="bP2-yc-Y9I" secondAttribute="trailing" constant="15" id="lGj-td-2os"/>
                                                         <constraint firstItem="TfY-fp-ztg" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="86" id="ngH-zT-yHH"/>
                                                         <constraint firstItem="9lJ-vz-FvC" firstAttribute="baseline" secondItem="LS6-bP-hJx" secondAttribute="baseline" id="nzy-ZL-Sa1"/>
                                                         <constraint firstItem="LS6-bP-hJx" firstAttribute="top" secondItem="QM0-hF-4j5" secondAttribute="top" constant="58" id="rya-Wt-38t"/>
-                                                        <constraint firstItem="7Lj-Se-MNx" firstAttribute="top" secondItem="TfY-fp-ztg" secondAttribute="bottom" constant="8" id="wex-ck-TG0"/>
                                                         <constraint firstItem="mbd-An-9Bi" firstAttribute="leading" secondItem="QM0-hF-4j5" secondAttribute="leading" constant="85" id="xOg-1s-CnG"/>
                                                         <constraint firstAttribute="centerX" secondItem="6Ki-wr-8K2" secondAttribute="centerX" constant="114.5" id="y73-f2-Vqn"/>
                                                     </constraints>
@@ -1403,6 +1399,7 @@
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
+            <point key="canvasLocation" x="142.5" y="147"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="6hU-Zy-Fpz"/>
         <customObject id="mvj-kT-UYD" customClass="LGPopularRepositories">
@@ -1492,6 +1489,7 @@ Gw
                 <outlet property="jssStatusLight" destination="gcn-rW-umQ" id="M4V-gw-vzW"/>
                 <outlet property="jssStatusSpinner" destination="6MF-CB-ccc" id="PIn-UW-oN1"/>
                 <outlet property="jssURLTF" destination="mbd-An-9Bi" id="cMm-Xd-54D"/>
+                <outlet property="jssUseMasterJDS" destination="lpc-x9-S3q" id="r4I-Dh-8WT"/>
                 <outlet property="modalWindow" destination="F0z-JX-Cv5" id="dcE-Mx-cM8"/>
             </connections>
         </customObject>

--- a/AutoPkgr/LGConfigurationWindowController.xib
+++ b/AutoPkgr/LGConfigurationWindowController.xib
@@ -312,7 +312,7 @@
                                                 </button>
                                                 <searchField wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Su6-Sd-cOj">
                                                     <rect key="frame" x="410" y="381" width="190" height="22"/>
-                                                    <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search repos by name" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" id="kxU-o8-COd">
+                                                    <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Filter repos by name" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" id="kxU-o8-COd">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -320,14 +320,14 @@
                                                 </searchField>
                                                 <searchField wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8hi-WA-S41">
                                                     <rect key="frame" x="410" y="170" width="190" height="22"/>
-                                                    <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search recipes by name" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" id="oqD-5E-S2C">
+                                                    <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Filter recipes by name" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" id="oqD-5E-S2C">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </searchFieldCell>
                                                 </searchField>
                                                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FaV-GR-28e">
-                                                    <rect key="frame" x="17" y="20" width="583" height="145"/>
+                                                    <rect key="frame" x="17" y="30" width="583" height="135"/>
                                                     <clipView key="contentView" id="gzb-cW-veF">
                                                         <rect key="frame" x="1" y="1" width="581" height="143"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -394,6 +394,19 @@
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                 </scrollView>
+                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4WY-w1-VqU">
+                                                    <rect key="frame" x="479" y="-2" width="126" height="28"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="116" id="b5d-Xi-gwZ"/>
+                                                    </constraints>
+                                                    <buttonCell key="cell" type="push" title="Search Github" bezelStyle="rounded" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="7va-qK-S1L">
+                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                    </buttonCell>
+                                                    <connections>
+                                                        <action selector="openSearchPanel:" target="mvj-kT-UYD" id="BGI-nk-u9C"/>
+                                                    </connections>
+                                                </button>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="Su6-Sd-cOj" firstAttribute="leading" secondItem="Kzw-up-jZN" secondAttribute="leading" constant="410" id="6vI-Yf-b4J"/>
@@ -401,7 +414,9 @@
                                                 <constraint firstItem="PWu-1D-EW1" firstAttribute="leading" secondItem="6E4-OJ-BCm" secondAttribute="trailing" constant="8" id="9v1-E9-CLu"/>
                                                 <constraint firstItem="FaV-GR-28e" firstAttribute="top" secondItem="8hi-WA-S41" secondAttribute="bottom" constant="5" id="Aze-19-6Fy"/>
                                                 <constraint firstItem="8hi-WA-S41" firstAttribute="leading" secondItem="Kzw-up-jZN" secondAttribute="leading" constant="410" id="Bid-UA-78I"/>
+                                                <constraint firstItem="4WY-w1-VqU" firstAttribute="trailing" secondItem="FaV-GR-28e" secondAttribute="trailing" id="CXd-6B-MT5"/>
                                                 <constraint firstItem="PWu-1D-EW1" firstAttribute="top" secondItem="9vg-XB-Pqv" secondAttribute="bottom" constant="6" id="Emi-va-fQb"/>
+                                                <constraint firstAttribute="bottom" secondItem="4WY-w1-VqU" secondAttribute="bottom" constant="4" id="HzR-5e-ENJ"/>
                                                 <constraint firstItem="OQZ-m7-NDG" firstAttribute="leading" secondItem="Kzw-up-jZN" secondAttribute="leading" constant="17" id="SbP-U4-3PG"/>
                                                 <constraint firstItem="9vg-XB-Pqv" firstAttribute="leading" secondItem="Kzw-up-jZN" secondAttribute="leading" constant="17" id="Tlf-qK-Hbq"/>
                                                 <constraint firstItem="PWu-1D-EW1" firstAttribute="baseline" secondItem="6E4-OJ-BCm" secondAttribute="baseline" id="UpW-7D-JoG"/>
@@ -409,7 +424,7 @@
                                                 <constraint firstItem="9vg-XB-Pqv" firstAttribute="top" secondItem="c6a-G7-vZU" secondAttribute="bottom" constant="11" id="Vwl-fc-iP9"/>
                                                 <constraint firstItem="8hi-WA-S41" firstAttribute="top" secondItem="mla-ao-F4d" secondAttribute="bottom" constant="18" id="XAk-w1-b9n"/>
                                                 <constraint firstItem="c6a-G7-vZU" firstAttribute="top" secondItem="Kzw-up-jZN" secondAttribute="top" constant="11" id="Xnh-7G-AZY"/>
-                                                <constraint firstAttribute="bottom" secondItem="FaV-GR-28e" secondAttribute="bottom" constant="20" id="YZB-fi-Pdf"/>
+                                                <constraint firstAttribute="bottom" secondItem="FaV-GR-28e" secondAttribute="bottom" constant="30" id="YZB-fi-Pdf"/>
                                                 <constraint firstItem="OQZ-m7-NDG" firstAttribute="top" secondItem="6E4-OJ-BCm" secondAttribute="bottom" constant="22" id="e9S-Zn-7IQ"/>
                                                 <constraint firstAttribute="trailing" secondItem="mla-ao-F4d" secondAttribute="trailing" constant="17" id="eZF-VL-o2Q"/>
                                                 <constraint firstAttribute="trailing" secondItem="9vg-XB-Pqv" secondAttribute="trailing" constant="17" id="i8a-Gw-IUA"/>

--- a/AutoPkgr/LGDefaults.h
+++ b/AutoPkgr/LGDefaults.h
@@ -44,7 +44,6 @@
 @property (nonatomic) BOOL SMTPAuthenticationEnabled;
 @property (nonatomic) BOOL hasCompletedInitialSetup;
 @property (nonatomic) BOOL sendEmailNotificationsWhenNewVersionsAreFoundEnabled;
-@property (nonatomic) BOOL checkForNewVersionsOfAppsAutomaticallyEnabled;
 @property (nonatomic) BOOL checkForRepoUpdatesAutomaticallyEnabled;
 
 #pragma mark - AutoPkg Defaults

--- a/AutoPkgr/LGDefaults.m
+++ b/AutoPkgr/LGDefaults.m
@@ -142,16 +142,6 @@
     [self setBool:SMTPAuthenticationEnabled forKey:kLGSMTPAuthenticationEnabled];
 }
 #pragma mark
-- (BOOL)warnBeforeQuittingEnabled
-{
-    return [self boolForKey:kLGWarnBeforeQuittingEnabled];
-}
-
-- (void)setWarnBeforeQuittingEnabled:(BOOL)WarnBeforeQuittingEnabled
-{
-    [self setBool:WarnBeforeQuittingEnabled forKey:kLGWarnBeforeQuittingEnabled];
-}
-#pragma mark
 - (BOOL)hasCompletedInitialSetup
 {
     return [self boolForKey:kLGHasCompletedInitialSetup];
@@ -171,16 +161,7 @@
 {
     [self setBool:SendEmailNotificationsWhenNewVersionsAreFoundEnabled forKey:kLGSendEmailNotificationsWhenNewVersionsAreFoundEnabled];
 }
-#pragma mark
-- (BOOL)checkForNewVersionsOfAppsAutomaticallyEnabled
-{
-    return [self boolForKey:kLGCheckForNewVersionsOfAppsAutomaticallyEnabled];
-}
 
-- (void)setCheckForNewVersionsOfAppsAutomaticallyEnabled:(BOOL)CheckForNewVersionsOfAppsAutomaticallyEnabled
-{
-    [self setBool:CheckForNewVersionsOfAppsAutomaticallyEnabled forKey:kLGCheckForNewVersionsOfAppsAutomaticallyEnabled];
-}
 #pragma mark
 - (BOOL)checkForRepoUpdatesAutomaticallyEnabled
 {

--- a/AutoPkgr/LGJSSDistributionPointsPrefPanel.xib
+++ b/AutoPkgr/LGJSSDistributionPointsPrefPanel.xib
@@ -120,14 +120,13 @@ Gw
                         <constraints>
                             <constraint firstAttribute="width" constant="235" id="RZ0-Jb-xx7"/>
                         </constraints>
-                        <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="Tm4-J4-erg">
+                        <popUpButtonCell key="cell" type="push" title="SMB" bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="3qb-HP-cZN" id="Tm4-J4-erg">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="menu"/>
                             <menu key="menu" id="2Hx-Ld-mHD">
                                 <items>
                                     <menuItem title="AFP" id="fZx-9Q-VwR"/>
-                                    <menuItem title="SMB" id="3qb-HP-cZN"/>
-                                    <menuItem title="JDS" id="Jjc-q4-79l"/>
+                                    <menuItem title="SMB" state="on" id="3qb-HP-cZN"/>
                                 </items>
                             </menu>
                         </popUpButtonCell>

--- a/AutoPkgr/LGJSSImporter.h
+++ b/AutoPkgr/LGJSSImporter.h
@@ -40,6 +40,7 @@
 
 @property (weak) IBOutlet NSButton *jssEditDistPointBT;
 @property (weak) IBOutlet NSButton *jssRemoveDistPointBT;
+@property (weak) IBOutlet NSButton *jssUseMasterJDS;
 
 @property (weak) IBOutlet NSWindow *modalWindow;
 
@@ -50,6 +51,7 @@
 - (IBAction)addDistributionPoint:(id)sender;
 - (IBAction)removeDistributionPoint:(id)sender;
 - (IBAction)editDistributionPoint:(id)sender;
+- (IBAction)enableMasterJDS:(NSButton *)sender;
 
 - (NSMenu *)contextualMenuForDistributionPoint:(NSDictionary *)distPoint;
 @end

--- a/AutoPkgr/LGPopularRepositories.h
+++ b/AutoPkgr/LGPopularRepositories.h
@@ -37,6 +37,8 @@
 + (NSMenu *)contextualMenuForRepo:(NSString *)repo;
 - (void)reload;
 
+@property (weak) IBOutlet NSWindow *modalWindow;
+
 @property (weak) IBOutlet LGTableView *popularRepositoriesTableView;
 @property (weak) IBOutlet NSSearchField *repoSearch;
 @property (weak) IBOutlet LGRecipes *recipesObject;

--- a/AutoPkgr/LGPopularRepositories.m
+++ b/AutoPkgr/LGPopularRepositories.m
@@ -21,8 +21,11 @@
 
 #import "LGPopularRepositories.h"
 #import "LGAutoPkgr.h"
+#import "LGRecipeSearch.h"
 
-@implementation LGPopularRepositories
+@implementation LGPopularRepositories{
+    LGRecipeSearch *_searchPanel;
+}
 
 - (id)init
 {
@@ -102,14 +105,14 @@
 - (void)assembleRepos
 {
     _activeRepos = [LGAutoPkgTask repoList];
-    NSMutableArray *workingPR = [NSMutableArray arrayWithArray:_popularRepos];
+    NSMutableArray *workingPR = [_popularRepos mutableCopy];
     for (NSDictionary *dict in _activeRepos) {
         if (![workingPR containsObject:dict[kLGAutoPkgRepoURLKey]]) {
             [workingPR addObject:dict[kLGAutoPkgRepoURLKey]];
         }
     }
 
-    _popularRepos = [NSArray arrayWithArray:workingPR];
+    _popularRepos = [workingPR copy];
     [self executeRepoSearch:nil];
 }
 
@@ -186,9 +189,32 @@
     // TODO: Eventually this could be setup for something
     // The AutoPkgTask repo-list needs to be reworked to send back an array of dicts.
     NSMenu *menu = [[NSMenu alloc] init];
-    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@"Reveal in Finder" action:nil keyEquivalent:@""];
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@"Reveal in Finder"
+                                                  action:nil keyEquivalent:@""];
     [menu addItem:item];
     return menu;
+}
+
+#pragma mark - Search Panel
+- (IBAction)openSearchPanel:(id)sender
+{
+    if (!_searchPanel) {
+        _searchPanel = [[LGRecipeSearch alloc] init];
+    }
+    
+    [NSApp beginSheet:_searchPanel.window
+       modalForWindow:self.modalWindow
+        modalDelegate:self
+       didEndSelector:@selector(didCloseSearchPanel)
+          contextInfo:NULL];
+}
+
+- (void)didCloseSearchPanel{
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        [_searchPanel.window close];
+        _searchPanel = nil;
+        [self reload];
+    }];
 }
 
 @end

--- a/AutoPkgr/LGRecipeSearch.h
+++ b/AutoPkgr/LGRecipeSearch.h
@@ -1,10 +1,8 @@
 //
-//  LGApplications.h
+//  LGRecipeSearch.h
 //  AutoPkgr
 //
-//  Created by Josh Senick on 7/10/14.
-//
-//  Copyright 2014 The Linde Group, Inc.
+//  Created by Eldon Ahrold on 12/19/14.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -17,20 +15,8 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-//
 
-#import <Foundation/Foundation.h>
-#import "LGAutoPkgTask.h"
-#import "LGTableView.h"
+#import <Cocoa/Cocoa.h>
 
-@interface LGRecipes : NSObject <NSApplicationDelegate, NSTableViewDataSource, NSTableViewDelegate>
-
-+ (NSString *)recipeList;
-+ (NSArray *)getActiveRecipes;
-
-- (void)reload;
-- (NSMenu *)contextualMenuForRecipeAtRow:(NSInteger)row;
-
-+ (BOOL)migrateToIdentifiers:(NSError**)error;
-
+@interface LGRecipeSearch : NSWindowController <NSTableViewDataSource, NSTableViewDelegate>
 @end

--- a/AutoPkgr/LGRecipeSearch.m
+++ b/AutoPkgr/LGRecipeSearch.m
@@ -1,0 +1,166 @@
+//
+//  LGRecipeSearch.m
+//  AutoPkgr
+//
+//  Created by Eldon Ahrold on 12/19/14.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#import "LGRecipeSearch.h"
+#import "LGAutoPkgr.h"
+#import "LGAutoPkgTask.h"
+#import "LGRecipes.h"
+
+@interface LGRecipeSearch () <NSTextViewDelegate>
+@property (weak) IBOutlet NSTableView *searchTable;
+@property (weak) IBOutlet NSButton *cancelBT;
+@property (weak) IBOutlet NSButton *addBT;
+@property (weak) IBOutlet NSSearchField *searchField;
+@property (weak) IBOutlet NSProgressIndicator *progressIndicator;
+@property (weak) IBOutlet NSTextField *limitMessage;
+
+@property (copy, nonatomic) NSArray *searchResults;
+@property (copy, nonatomic) NSArray *currentlyInstalledRepos;
+
+@end
+
+@implementation LGRecipeSearch
+
+#pragma mark - Init / Load
+- (void)dealloc
+{
+    // On dealloc nil out the dataSource and delegate to prevent
+    // KVO messages getting sent to the searchTable after
+    // deallocation of the LGRecipeSearch object
+    _searchTable.dataSource = nil;
+    _searchTable.delegate = nil;
+}
+
+- (id)init
+{
+    return [self initWithWindowNibName:@"LGRecipeSearchPanel"];
+}
+
+- (void)windowDidLoad
+{
+    [super windowDidLoad];
+    _progressIndicator.hidden = YES;
+    _currentlyInstalledRepos = [LGAutoPkgTask repoList];
+}
+
+#pragma mark - IBActions
+- (IBAction)searchNow:(NSSearchField *)sender
+{
+    NSString *searchString = sender.safeStringValue;
+    if (searchString) {
+        [_progressIndicator setHidden:NO];
+        [_progressIndicator startAnimation:nil];
+
+        [LGAutoPkgTask search:searchString
+                        reply:^(NSArray *results, NSError *error) {
+                            [_progressIndicator stopAnimation:nil];
+                            [_progressIndicator setHidden:YES];
+                            if (error) {
+                                _limitMessage.hidden = NO;
+                                NSLog(@"%@",error);
+                            } else {
+                                _limitMessage.hidden = YES;
+                                _searchResults = results;
+                                [_searchTable reloadData];
+                            }
+                        }];
+    }
+}
+
+- (IBAction)addRecipeAndRepo:(NSButton *)sender
+{
+    NSString *repoName = _searchResults[_searchTable.selectedRow][kLGAutoPkgRepoNameKey];
+    NSString *url = [NSString stringWithFormat:@"https://github.com/autopkg/%@.git", repoName];
+
+    [_progressIndicator startAnimation:nil];
+    [_progressIndicator setHidden:NO];
+
+    [LGAutoPkgTask repoAdd:url reply:^(NSError *error) {
+        [_progressIndicator stopAnimation:nil];
+        [_progressIndicator setHidden:YES];
+        if (error) {
+            NSLog(@"%@", error.localizedDescription);
+        } else {
+            _currentlyInstalledRepos = [LGAutoPkgTask repoList];
+            [_addBT setEnabled:NO];
+            [_searchTable reloadData];
+        }
+    }];
+}
+
+- (IBAction)closePanel:(id)sender
+{
+    [NSApp endSheet:self.window];
+}
+
+#pragma mark - Table View Delegate / Data Source
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView
+{
+    return [_searchResults count];
+}
+
+- (id)tableView:(NSTableView *)tableView objectValueForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
+{
+    if (row < _searchResults.count) {
+        if ([tableColumn.identifier isEqualToString:@"installed"]) {
+            NSString *match = _searchResults[row][kLGAutoPkgRepoNameKey];
+            NSPredicate *predicate = [self repoMatchPredicate:match];
+
+            return ([_currentlyInstalledRepos filteredArrayUsingPredicate:predicate].count) ? [NSImage LGStatusAvailable] : [NSImage LGStatusNone];
+        } else {
+            return [[_searchResults objectAtIndex:row] objectForKey:[tableColumn identifier]];
+        }
+    }
+    return nil;
+}
+
+- (void)tableViewSelectionDidChange:(NSNotification *)notification
+{
+    NSInteger row = [notification.object selectedRow];
+    if (row < _searchResults.count && row > -1) {
+        NSString *match = _searchResults[row][kLGAutoPkgRepoNameKey];
+        NSPredicate *predicate = [self repoMatchPredicate:match];
+
+        if ([_currentlyInstalledRepos filteredArrayUsingPredicate:predicate].count) {
+            [_addBT setEnabled:NO];
+        } else {
+            [_addBT setEnabled:YES];
+        }
+    }
+}
+
+#pragma mark - Text View Delegate
+- (void)controlTextDidEndEditing:(NSNotification *)notification
+{
+    // Though a subclass of NSTextField, the NSSearchField isn't respecting
+    // "Send on enter only" set in the XIB, or even programatically , so we're
+    //  using the TextView delegate here to do force that behavior.
+    if ([notification.object isEqualTo:_searchField]) {
+        if ([notification.userInfo[@"NSTextMovement"] intValue] == NSReturnTextMovement) {
+            [self searchNow:notification.object];
+        }
+    }
+}
+
+#pragma mark - Utility
+- (NSPredicate *)repoMatchPredicate:(NSString *)match
+{
+    return [NSPredicate predicateWithFormat:@"%K.lastPathComponent == %@", kLGAutoPkgRepoURLKey, [match stringByAppendingPathExtension:@"git"]];
+}
+
+@end

--- a/AutoPkgr/LGRecipeSearchPanel.xib
+++ b/AutoPkgr/LGRecipeSearchPanel.xib
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6250" systemVersion="13E28" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6250"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="LGRecipeSearch">
+            <connections>
+                <outlet property="addBT" destination="gEj-8x-XrO" id="QQF-br-hNF"/>
+                <outlet property="cancelBT" destination="Eht-cl-LtU" id="W6Q-T8-m8N"/>
+                <outlet property="limitMessage" destination="ORW-oU-9em" id="c0f-w3-CwW"/>
+                <outlet property="progressIndicator" destination="llE-7y-lSY" id="Mer-5a-6Q2"/>
+                <outlet property="searchField" destination="0FY-e4-SV7" id="p16-CB-Zn4"/>
+                <outlet property="searchTable" destination="f7k-cu-1LO" id="STi-Qj-5Lm"/>
+                <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" visibleAtLaunch="NO" animationBehavior="default" id="F0z-JX-Cv5">
+            <windowStyleMask key="styleMask" titled="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="196" y="240" width="600" height="300"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
+            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="600" height="300"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jQo-0g-7xF">
+                        <rect key="frame" x="20" y="72" width="556" height="184"/>
+                        <clipView key="contentView" id="R4N-zl-cdH">
+                            <rect key="frame" x="1" y="17" width="238" height="117"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" headerView="uoi-8d-oaY" id="f7k-cu-1LO">
+                                    <rect key="frame" x="0.0" y="0.0" width="554" height="19"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <size key="intercellSpacing" width="3" height="2"/>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                    <tableColumns>
+                                        <tableColumn identifier="Name" width="208.078125" minWidth="40" maxWidth="1000" id="R6H-6k-fdA">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" alignment="left" title="Text Cell" id="GU5-No-Y7U">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                        </tableColumn>
+                                        <tableColumn identifier="RepoName" width="244.1484375" minWidth="40" maxWidth="1000" id="7xK-H0-SVX">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" alignment="left" title="Text Cell" id="ec3-q2-68c">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                        </tableColumn>
+                                        <tableColumn identifier="installed" width="93" minWidth="10" maxWidth="3.4028234663852886e+38" id="Te5-R7-pY1">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Repo Installed">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                            </tableHeaderCell>
+                                            <imageCell key="dataCell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="Lep-UN-DpD"/>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                        </tableColumn>
+                                    </tableColumns>
+                                    <connections>
+                                        <outlet property="dataSource" destination="-2" id="pr2-oq-DsK"/>
+                                        <outlet property="delegate" destination="-2" id="URA-ns-e3A"/>
+                                    </connections>
+                                </tableView>
+                            </subviews>
+                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </clipView>
+                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="CS2-fe-iN9">
+                            <rect key="frame" x="1" y="119" width="223" height="15"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="u6W-bg-JRG">
+                            <rect key="frame" x="224" y="17" width="15" height="102"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <tableHeaderView key="headerView" id="uoi-8d-oaY">
+                            <rect key="frame" x="0.0" y="0.0" width="238" height="17"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </tableHeaderView>
+                    </scrollView>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gEj-8x-XrO">
+                        <rect key="frame" x="500" y="12" width="82" height="32"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="70" id="djw-UA-UKI"/>
+                        </constraints>
+                        <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="E0Y-sn-caq">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="addRecipeAndRepo:" target="-2" id="PgA-xn-FHs"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Eht-cl-LtU">
+                        <rect key="frame" x="426" y="12" width="74" height="32"/>
+                        <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="V3k-V9-S34">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="closePanel:" target="-2" id="fy0-T7-wOc"/>
+                        </connections>
+                    </button>
+                    <searchField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0FY-e4-SV7">
+                        <rect key="frame" x="20" y="264" width="216" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="216" id="Xmc-l0-sEi"/>
+                        </constraints>
+                        <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="GgT-uP-FJN">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </searchFieldCell>
+                        <connections>
+                            <outlet property="delegate" destination="-2" id="G1O-Lb-VVI"/>
+                        </connections>
+                    </searchField>
+                    <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="llE-7y-lSY">
+                        <rect key="frame" x="244" y="267" width="16" height="16"/>
+                    </progressIndicator>
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TLS-hE-fLt">
+                        <rect key="frame" x="18" y="53" width="560" height="16"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="16" id="Ii0-v3-jVt"/>
+                        </constraints>
+                        <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="This panel will only add the recipe repo. Enable individual recipes back in the main window." id="oZH-U7-Wko">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ORW-oU-9em">
+                        <rect key="frame" x="201" y="267" width="377" height="16"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="373" id="40M-ey-sSY"/>
+                        </constraints>
+                        <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="The GitHub API has a limit of 5 searches per minute." id="lZX-La-Pof">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" red="0.712890625" green="0.024089717045036027" blue="0.0059326041652718875" alpha="1" colorSpace="calibratedRGB"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="0FY-e4-SV7" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="14" id="0U6-35-YdR"/>
+                    <constraint firstItem="0FY-e4-SV7" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="20" symbolic="YES" id="40a-Dk-6bT"/>
+                    <constraint firstItem="TLS-hE-fLt" firstAttribute="trailing" secondItem="jQo-0g-7xF" secondAttribute="trailing" id="9Oh-A1-xiN"/>
+                    <constraint firstItem="gEj-8x-XrO" firstAttribute="baseline" secondItem="Eht-cl-LtU" secondAttribute="baseline" id="AkG-zv-X6o"/>
+                    <constraint firstAttribute="bottom" secondItem="Eht-cl-LtU" secondAttribute="bottom" constant="19" id="Gdg-ir-2eh"/>
+                    <constraint firstItem="Eht-cl-LtU" firstAttribute="top" secondItem="TLS-hE-fLt" secondAttribute="bottom" constant="13" id="Jlt-6V-sM8"/>
+                    <constraint firstItem="TLS-hE-fLt" firstAttribute="top" secondItem="jQo-0g-7xF" secondAttribute="bottom" constant="3" id="OGe-d6-GTK"/>
+                    <constraint firstItem="ORW-oU-9em" firstAttribute="top" secondItem="llE-7y-lSY" secondAttribute="top" id="TYt-AW-68S"/>
+                    <constraint firstItem="gEj-8x-XrO" firstAttribute="trailing" secondItem="TLS-hE-fLt" secondAttribute="trailing" id="TZi-hO-U5z"/>
+                    <constraint firstItem="llE-7y-lSY" firstAttribute="leading" secondItem="0FY-e4-SV7" secondAttribute="trailing" constant="8" symbolic="YES" id="aTs-xA-Vs3"/>
+                    <constraint firstItem="0FY-e4-SV7" firstAttribute="centerY" secondItem="llE-7y-lSY" secondAttribute="centerY" id="hSc-xW-nuk"/>
+                    <constraint firstItem="jQo-0g-7xF" firstAttribute="top" secondItem="0FY-e4-SV7" secondAttribute="bottom" constant="8" symbolic="YES" id="iHa-Mp-SFA"/>
+                    <constraint firstItem="ORW-oU-9em" firstAttribute="baseline" secondItem="0FY-e4-SV7" secondAttribute="baseline" id="jTx-wG-bdd"/>
+                    <constraint firstItem="ORW-oU-9em" firstAttribute="trailing" secondItem="jQo-0g-7xF" secondAttribute="trailing" id="ldp-3I-NGB"/>
+                    <constraint firstItem="gEj-8x-XrO" firstAttribute="leading" secondItem="Eht-cl-LtU" secondAttribute="trailing" constant="12" symbolic="YES" id="rJ3-lj-IxC"/>
+                    <constraint firstItem="TLS-hE-fLt" firstAttribute="leading" secondItem="jQo-0g-7xF" secondAttribute="leading" id="vvb-WY-iw0"/>
+                    <constraint firstAttribute="trailing" secondItem="jQo-0g-7xF" secondAttribute="trailing" constant="24" id="wg4-VD-4cO"/>
+                    <constraint firstItem="jQo-0g-7xF" firstAttribute="leading" secondItem="0FY-e4-SV7" secondAttribute="leading" id="y8L-o8-aVf"/>
+                </constraints>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+            </connections>
+            <point key="canvasLocation" x="198" y="158"/>
+        </window>
+    </objects>
+</document>

--- a/AutoPkgr/LGRecipes.h
+++ b/AutoPkgr/LGRecipes.h
@@ -25,12 +25,49 @@
 
 @interface LGRecipes : NSObject <NSApplicationDelegate, NSTableViewDataSource, NSTableViewDelegate>
 
+/**
+ *  Path to the recipe_list.txt file.
+ *
+ *  @return Path to the recipe_list.txt file
+ */
 + (NSString *)recipeList;
+
+/**
+ *  Remove a recipe from the recipe list by name.
+ *
+ *  @param recipe Name of the recipe to remove
+ */
++ (void)removeRecipeFromRecipeList:(NSString *)recipe;
+
+/**
+ *  Write an array to the recipe list file.
+ *
+ *  @param recipes array of recipes
+ */
++ (void)writeRecipeList:(NSMutableArray *)recipes;
+
+/**
+ *  Array of the recipes currently in the recipe_list.txt.
+ *
+ *  @return NSArray of recipes.
+ */
 + (NSArray *)getActiveRecipes;
 
+/**
+ *  Migrate a recipe_list.txt file from recipe shortnames to recipe identifiers.
+ *
+ *  @param error populated error object if any error occurs during migration.
+ *
+ *  @return YES if conversion was successful, NO if any error occured, even minor errors.
+ */
++ (BOOL)migrateToIdentifiers:(NSError**)error;
+
+/**
+ *  reload the Recipe TableView
+ */
 - (void)reload;
+
 - (NSMenu *)contextualMenuForRecipeAtRow:(NSInteger)row;
 
-+ (BOOL)migrateToIdentifiers:(NSError**)error;
 
 @end


### PR DESCRIPTION
@homebysix 
Here is the rework that simplifies for the new JSS_REPO entry for use with a JDS.
This is built off of the search branch #246, which I've been testing regularly for a week, so merging this will bring all of those changes too.

The constraints for the "Add/Remove/Edit/User Master JDS" buttons are a bit off and need to be tweaked if you could take a look at that.

Otherwise, once this, and the Installer class rework is merged, I think 1.2 will be ready to move to a RC and begin final testing.
How does that sound to you?