### PR TITLE
Launch At Login / Display Mode

### DIFF
--- a/AutoPkgr/AutoPkgr-Info.plist
+++ b/AutoPkgr/AutoPkgr-Info.plist
@@ -26,6 +26,8 @@
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2014-2015 The Linde Group, Inc.</string>
 	<key>NSMainNibFile</key>

--- a/AutoPkgr/LGAppDelegate.m
+++ b/AutoPkgr/LGAppDelegate.m
@@ -52,8 +52,8 @@
     // Setup activation policy. By default set as menubar only.
     [[LGDefaults standardUserDefaults] registerDefaults:@{ kLGApplicationDisplayStyle : @(kLGDisplayStyleMenuBarOnly) }];
 
-    if ([[LGDefaults standardUserDefaults] applicationDisplayStyle] == kLGDisplayStyleMenuBarOnly) {
-        [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+    if ([[LGDefaults standardUserDefaults] applicationDisplayStyle] != kLGDisplayStyleMenuBarOnly) {
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
     }
 }
 

--- a/AutoPkgr/LGAutoPkgSchedule.h
+++ b/AutoPkgr/LGAutoPkgSchedule.h
@@ -22,10 +22,14 @@
 #import <Foundation/Foundation.h>
 #import "LGProgressDelegate.h"
 
+extern NSString *const kLGLaunchedAtLogin;
+
 @interface LGAutoPkgSchedule : NSObject
 
 + (void)startAutoPkgSchedule:(BOOL)start interval:(NSInteger)interval isForced:(BOOL)forced reply:(void (^)(NSError *error))reply;
 
 + (BOOL)updateAppsIsScheduled:(NSInteger *)scheduleInterval;
 
++ (BOOL)launchAtLogin:(BOOL)launch;
++ (BOOL)willLaunchAtLogin;
 @end

--- a/AutoPkgr/LGConfigurationWindowController.h
+++ b/AutoPkgr/LGConfigurationWindowController.h
@@ -46,12 +46,14 @@
 @property (weak) IBOutlet NSButton *checkForNewVersionsOfAppsAutomaticallyButton;
 @property (weak) IBOutlet NSButton *checkForRepoUpdatesAutomaticallyButton;
 @property (weak) IBOutlet NSButton *sendEmailNotificationsWhenNewVersionsAreFoundButton;
+@property (weak) IBOutlet NSButton *launchAtLoginButton;
 
 // Buttons
 @property (weak) IBOutlet NSButton *openLocalMunkiRepoFolderButton;
 @property (weak) IBOutlet NSButton *openAutoPkgRecipeReposFolderButton;
 @property (weak) IBOutlet NSButton *openAutoPkgCacheFolderButton;
 @property (weak) IBOutlet NSButton *openAutoPkgRecipeOverridesFolderButton;
+@property (weak) IBOutlet NSPopUpButton *applicationDisplayModeButton;
 
 @property (weak) IBOutlet NSButton *sendTestEmailButton;
 @property (weak) IBOutlet NSButton *installGitButton;

--- a/AutoPkgr/LGConfigurationWindowController.xib
+++ b/AutoPkgr/LGConfigurationWindowController.xib
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6250" systemVersion="13F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6250"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="LGConfigurationWindowController">
             <connections>
+                <outlet property="applicationDisplayModeButton" destination="ogp-qB-F3c" id="STd-SF-rjX"/>
                 <outlet property="autoPkgCacheDir" destination="fAS-2t-NJR" id="IWd-LX-9p0"/>
                 <outlet property="autoPkgRecipeOverridesDir" destination="KC4-Ks-uGR" id="ydL-sc-Gjg"/>
                 <outlet property="autoPkgRecipeRepoDir" destination="Tl2-iz-Ard" id="a6L-QG-NtU"/>
@@ -21,6 +22,7 @@
                 <outlet property="gitStatusLabel" destination="OPb-IV-o9L" id="iUI-9q-yU4"/>
                 <outlet property="installAutoPkgButton" destination="x1S-bd-tl3" id="4PM-4V-zR4"/>
                 <outlet property="installGitButton" destination="ClY-1a-e2c" id="FKm-rN-CAw"/>
+                <outlet property="launchAtLoginButton" destination="gCc-Bk-Xo8" id="0dU-nm-AKI"/>
                 <outlet property="localMunkiRepo" destination="ME9-rG-Y8o" id="ejh-Qk-6mT"/>
                 <outlet property="openAutoPkgCacheFolderButton" destination="TYE-36-bIi" id="xbC-TJ-DYP"/>
                 <outlet property="openAutoPkgRecipeOverridesFolderButton" destination="SPx-dH-wAP" id="xtp-uW-mVy"/>
@@ -55,7 +57,7 @@
         <window title="AutoPkgr" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="196" y="240" width="657" height="478"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="657" height="478"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="657" height="478"/>
@@ -159,9 +161,55 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="d6J-YV-vkt">
+                                                    <rect key="frame" x="211" y="10" width="80" height="14"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="76" id="5uX-W4-BB7"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Display Style:" id="Lf7-x7-XW6">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <button autoresizesSubviews="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gCc-Bk-Xo8">
+                                                    <rect key="frame" x="241" y="40" width="135" height="18"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="131" id="Xgk-6S-QjL"/>
+                                                    </constraints>
+                                                    <buttonCell key="cell" type="check" title="Launch At Login" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="FsQ-sy-cGX">
+                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                        <font key="font" metaFont="system"/>
+                                                    </buttonCell>
+                                                    <connections>
+                                                        <action selector="launchAtLogin:" target="-2" id="sgX-Be-rnI"/>
+                                                    </connections>
+                                                </button>
+                                                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ogp-qB-F3c">
+                                                    <rect key="frame" x="286" y="5" width="120" height="22"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="114" id="czo-WY-35O"/>
+                                                    </constraints>
+                                                    <popUpButtonCell key="cell" type="push" title="Status menu only" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" arrowPosition="arrowAtCenter" selectedItem="0Mx-gF-xFh" id="2Tu-mo-HVT">
+                                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <menu key="menu" id="Qj9-h0-NgI">
+                                                            <items>
+                                                                <menuItem title="Status menu only" state="on" id="0Mx-gF-xFh"/>
+                                                                <menuItem title="Dock only" tag="1" id="1n8-kv-5cz"/>
+                                                                <menuItem title="Menu &amp; Dock" tag="2" id="ERc-fv-8yc"/>
+                                                            </items>
+                                                        </menu>
+                                                    </popUpButtonCell>
+                                                    <connections>
+                                                        <action selector="changeDisplayMode:" target="-2" id="hzv-Eh-N1w"/>
+                                                    </connections>
+                                                </popUpButton>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="x1S-bd-tl3" firstAttribute="width" secondItem="ClY-1a-e2c" secondAttribute="width" id="0Rl-Lx-Jc3"/>
+                                                <constraint firstItem="gCc-Bk-Xo8" firstAttribute="centerX" secondItem="pCK-5F-Geg" secondAttribute="centerX" id="9H8-r2-edT"/>
+                                                <constraint firstItem="ogp-qB-F3c" firstAttribute="leading" secondItem="d6J-YV-vkt" secondAttribute="trailing" id="CZB-qJ-5Ec"/>
                                                 <constraint firstAttribute="centerY" secondItem="0VQ-id-jlf" secondAttribute="centerY" constant="-82.5" id="ETF-Ck-fcB"/>
                                                 <constraint firstAttribute="centerY" secondItem="OPb-IV-o9L" secondAttribute="centerY" constant="-0.5" id="HJB-aJ-VZc"/>
                                                 <constraint firstItem="0VQ-id-jlf" firstAttribute="leading" secondItem="kGA-EW-Dsj" secondAttribute="trailing" constant="8" id="Ilm-j4-FZk"/>
@@ -169,18 +217,24 @@
                                                 <constraint firstAttribute="centerY" secondItem="uPW-I4-WKp" secondAttribute="centerY" constant="-82.5" id="LFC-Jf-Wb6"/>
                                                 <constraint firstItem="kGA-EW-Dsj" firstAttribute="leading" secondItem="uPW-I4-WKp" secondAttribute="trailing" constant="8" id="Lth-EM-SPJ"/>
                                                 <constraint firstAttribute="centerY" secondItem="ClY-1a-e2c" secondAttribute="centerY" constant="-0.5" id="N8x-Zq-eZh"/>
+                                                <constraint firstItem="d6J-YV-vkt" firstAttribute="trailing" secondItem="uPW-I4-WKp" secondAttribute="trailing" id="PA8-0m-49i"/>
+                                                <constraint firstItem="ogp-qB-F3c" firstAttribute="leading" secondItem="d6J-YV-vkt" secondAttribute="trailing" id="QV1-T3-gyy"/>
                                                 <constraint firstItem="ClY-1a-e2c" firstAttribute="top" secondItem="geX-ws-F4Z" secondAttribute="bottom" constant="34" id="RQL-OF-L3T"/>
                                                 <constraint firstAttribute="centerX" secondItem="geX-ws-F4Z" secondAttribute="centerX" constant="3" id="Reb-Xt-jOv"/>
+                                                <constraint firstItem="ogp-qB-F3c" firstAttribute="top" secondItem="gCc-Bk-Xo8" secondAttribute="bottom" constant="16" id="TSK-L8-aGB"/>
                                                 <constraint firstItem="OPb-IV-o9L" firstAttribute="leading" secondItem="KkE-qM-Hy6" secondAttribute="trailing" constant="8" id="UnX-zf-qdl"/>
+                                                <constraint firstItem="ogp-qB-F3c" firstAttribute="top" secondItem="gCc-Bk-Xo8" secondAttribute="bottom" constant="16" id="VAX-0w-fuT"/>
                                                 <constraint firstAttribute="centerX" secondItem="x1S-bd-tl3" secondAttribute="centerX" constant="116.5" id="XUL-CE-c2g"/>
                                                 <constraint firstAttribute="centerY" secondItem="geX-ws-F4Z" secondAttribute="centerY" constant="112.5" id="Z08-sL-Osx"/>
                                                 <constraint firstAttribute="centerY" secondItem="x1S-bd-tl3" secondAttribute="centerY" constant="-41.5" id="ZOr-1h-lJO"/>
                                                 <constraint firstAttribute="centerY" secondItem="KkE-qM-Hy6" secondAttribute="centerY" constant="-1" id="ZYd-MU-r2r"/>
+                                                <constraint firstItem="gCc-Bk-Xo8" firstAttribute="top" secondItem="uPW-I4-WKp" secondAttribute="bottom" constant="57" id="c6e-Cf-qTS"/>
                                                 <constraint firstItem="f8q-xY-QUg" firstAttribute="leading" secondItem="x1S-bd-tl3" secondAttribute="trailing" constant="8" id="cra-8T-RjN"/>
                                                 <constraint firstAttribute="centerX" secondItem="ClY-1a-e2c" secondAttribute="centerX" constant="116.5" id="g7p-PG-fiZ"/>
                                                 <constraint firstItem="Pbf-A7-T4b" firstAttribute="leading" secondItem="f8q-xY-QUg" secondAttribute="trailing" constant="8" id="jqJ-1g-M7m"/>
                                                 <constraint firstAttribute="centerY" secondItem="kGA-EW-Dsj" secondAttribute="centerY" constant="-83" id="keY-ao-C57"/>
                                                 <constraint firstItem="KkE-qM-Hy6" firstAttribute="leading" secondItem="ClY-1a-e2c" secondAttribute="trailing" constant="8" id="oHr-K9-shF"/>
+                                                <constraint firstItem="ogp-qB-F3c" firstAttribute="centerY" secondItem="d6J-YV-vkt" secondAttribute="centerY" id="pId-uK-WGA"/>
                                                 <constraint firstAttribute="centerY" secondItem="f8q-xY-QUg" secondAttribute="centerY" constant="-42" id="poa-PN-pTo"/>
                                                 <constraint firstAttribute="centerY" secondItem="Pbf-A7-T4b" secondAttribute="centerY" constant="-41.5" id="sK0-IT-bXJ"/>
                                                 <constraint firstItem="uPW-I4-WKp" firstAttribute="width" secondItem="x1S-bd-tl3" secondAttribute="width" id="yyb-LM-xIe"/>
@@ -268,7 +322,7 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6E4-OJ-BCm">
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6E4-OJ-BCm">
                                                     <rect key="frame" x="15" y="212" width="167" height="17"/>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Add a repo URL manually:" id="1IN-jG-Kev">
                                                         <font key="font" metaFont="system"/>
@@ -276,7 +330,7 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PWu-1D-EW1">
+                                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PWu-1D-EW1">
                                                     <rect key="frame" x="188" y="210" width="350" height="22"/>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="https://github.com/autopkg/recipes.git" drawsBackground="YES" id="hVj-tR-yVr">
                                                         <font key="font" metaFont="system"/>
@@ -1179,7 +1233,7 @@
                                                             </button>
                                                             <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TfY-fp-ztg">
                                                                 <rect key="frame" x="18" y="40" width="567" height="63"/>
-                                                                <clipView key="contentView" misplaced="YES" copiesOnScroll="NO" id="5gb-a9-yN0">
+                                                                <clipView key="contentView" copiesOnScroll="NO" id="5gb-a9-yN0">
                                                                     <rect key="frame" x="1" y="17" width="531" height="57"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
@@ -1209,7 +1263,7 @@
                                                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                                     </tableHeaderCell>
-                                                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="center" title="Text Cell" placeholderString="&lt;From JSS&gt;" id="gE4-uk-wy9">
+                                                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="center" title="Text Cell" placeholderString="&lt;From JSS>" id="gE4-uk-wy9">
                                                                                         <font key="font" metaFont="system"/>
                                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1235,7 +1289,7 @@
                                                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                                     </tableHeaderCell>
-                                                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="center" title="Text Cell" placeholderString="&lt;Auto&gt;" id="zpI-Gi-czw">
+                                                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="center" title="Text Cell" placeholderString="&lt;Auto>" id="zpI-Gi-czw">
                                                                                         <font key="font" metaFont="system"/>
                                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1248,7 +1302,7 @@
                                                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                                     </tableHeaderCell>
-                                                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" alignment="center" title="Text Cell" placeholderString="&lt;Auto&gt;" id="JFs-SL-g7N">
+                                                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" alignment="center" title="Text Cell" placeholderString="&lt;Auto>" id="JFs-SL-g7N">
                                                                                         <font key="font" metaFont="system"/>
                                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1406,7 +1460,7 @@
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="142.5" y="147"/>
+            <point key="canvasLocation" x="142.5" y="133"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="6hU-Zy-Fpz"/>
         <customObject id="mvj-kT-UYD" customClass="LGPopularRepositories">
@@ -1426,7 +1480,7 @@
             <windowStyleMask key="styleMask" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="385" y="323" width="610" height="133"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <view key="contentView" id="dCS-sn-B3a">
                 <rect key="frame" x="0.0" y="0.0" width="610" height="133"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/AutoPkgr/LGConstants.h
+++ b/AutoPkgr/LGConstants.h
@@ -60,6 +60,7 @@ extern NSString *const kLGCheckForRepoUpdatesAutomaticallyEnabled;
 extern NSString *const kLGSMTPTLSEnabled;
 extern NSString *const kLGSMTPAuthenticationEnabled;
 extern NSString *const kLGWarnBeforeQuittingEnabled;
+extern NSString *const kLGApplicationDisplayStyle;
 
 #pragma mark - Notifications
 #pragma mark-- Progress

--- a/AutoPkgr/LGConstants.m
+++ b/AutoPkgr/LGConstants.m
@@ -65,6 +65,7 @@ NSString *const kLGSendEmailNotificationsWhenNewVersionsAreFoundEnabled = @"Send
 NSString *const kLGCheckForNewVersionsOfAppsAutomaticallyEnabled = @"CheckForNewVersionsOfAppsAutomaticallyEnabled";
 NSString *const kLGCheckForRepoUpdatesAutomaticallyEnabled = @"CheckForRepoUpdatesAutomaticallyEnabled";
 NSString *const kLGWarnBeforeQuittingEnabled = @"WarnBeforeQuitting";
+NSString *const kLGApplicationDisplayStyle = @"ApplicationDisplayStyle";
 
 #pragma mark - Notifications
 #pragma mark-- Progress

--- a/AutoPkgr/LGDefaults.h
+++ b/AutoPkgr/LGDefaults.h
@@ -21,6 +21,12 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSInteger, LGApplicationDisplayStyle) {
+    kLGDisplayStyleMenuBarOnly,
+    kLGDisplayStyleDockOnly,
+    kLGDisplayStyleBoth,
+};
+
 @interface LGDefaults : NSUserDefaults
 
 #pragma mark - Singletons
@@ -43,6 +49,8 @@
 @property (nonatomic) BOOL SMTPTLSEnabled;
 @property (nonatomic) BOOL SMTPAuthenticationEnabled;
 @property (nonatomic) BOOL hasCompletedInitialSetup;
+@property (nonatomic) NSInteger applicationDisplayStyle;
+
 @property (nonatomic) BOOL sendEmailNotificationsWhenNewVersionsAreFoundEnabled;
 @property (nonatomic) BOOL checkForRepoUpdatesAutomaticallyEnabled;
 

--- a/AutoPkgr/LGDefaults.m
+++ b/AutoPkgr/LGDefaults.m
@@ -153,6 +153,18 @@
 {
     [self setBool:HasCompletedInitialSetup forKey:kLGHasCompletedInitialSetup];
 }
+
+#pragma mark
+- (NSInteger)applicationDisplayStyle
+{
+    return [self integerForKey:kLGApplicationDisplayStyle];
+}
+
+- (void)setApplicationDisplayStyle:(NSInteger)applicationDisplayStyle
+{
+    [self setInteger:applicationDisplayStyle forKey:kLGApplicationDisplayStyle];
+}
+
 #pragma mark
 - (BOOL)sendEmailNotificationsWhenNewVersionsAreFoundEnabled
 {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -29,7 +29,7 @@ DEPENDENCIES:
   - AFNetworking (~> 2.4.1)
   - AHCodesignVerifier (~> 0.1)
   - AHKeychain (~> 0.2)
-  - AHLaunchCtl (~> 0.3)
+  - AHLaunchCtl (~> 0.3.1)
   - AHProxySettings (~> 0.1.1)
   - mailcore2-osx (~> 0.5)
   - Sparkle (= 1.8)


### PR DESCRIPTION
#### Display Mode
It's looking OK, but maybe a bit busy.
I'm somewhat willing to concede removing the button, as long as we keep the code as an easter egg.

Give it a look and if you want to keep it and feel like you can clean up the UI a little bit, great. Othewise let me know and I'll
drop the button, and clean up the references in code.

How it is externally set now is slightly different too since I used a typedef enum.
``` 
defaults write com.lindegroup.AutoPkgr ApplicationDisplayStyle 0
```
Where 
0 = Status menu only
1 = Dock only
2 = Status menu and Dock


#### Launch at Login
Launch At Login feature is managed via launchd  by creating a file `~/Library/LaunchAgents/com.lindegroup.AutoPkgr.launcher.plist` 
I like this technique because it really keeps things simple.

It passes in a single argument `LaunchedAtLogin` used to defer launching of the configuration window. 

AHLaunchCtl pod was updated.
