### PR TITLE
Use system keychain. Improve security of helper tool.

### DIFF
--- a/AutoPkgr.xcodeproj/project.pbxproj
+++ b/AutoPkgr.xcodeproj/project.pbxproj
@@ -34,6 +34,9 @@
 		BE025CF719BAE93400D36345 /* LGAutoPkgTask.m in Sources */ = {isa = PBXBuildFile; fileRef = BE025CF519BAE93400D36345 /* LGAutoPkgTask.m */; };
 		BE025CFE19BAEF8800D36345 /* LGAutoPkgSchedule.m in Sources */ = {isa = PBXBuildFile; fileRef = BE025CFD19BAEF8800D36345 /* LGAutoPkgSchedule.m */; };
 		BE025CFF19BAEF8800D36345 /* LGAutoPkgSchedule.m in Sources */ = {isa = PBXBuildFile; fileRef = BE025CFD19BAEF8800D36345 /* LGAutoPkgSchedule.m */; };
+		BE053D151A8F90920021D97B /* LGPasswords.m in Sources */ = {isa = PBXBuildFile; fileRef = BE053D141A8F90920021D97B /* LGPasswords.m */; };
+		BE053D181A8F9DAA0021D97B /* SNTCodesignChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = BE053D171A8F9DAA0021D97B /* SNTCodesignChecker.m */; };
+		BE053D1B1A8F9DC00021D97B /* SNTCertificate.m in Sources */ = {isa = PBXBuildFile; fileRef = BE053D1A1A8F9DC00021D97B /* SNTCertificate.m */; };
 		BE05CE6A19DAF26B0089068B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05CE6919DAF26B0089068B /* main.m */; };
 		BE05CE7519DAF4DA0089068B /* com.lindegroup.AutoPkgr.helper in Copy Files: Helper Tool */ = {isa = PBXBuildFile; fileRef = BE05CE6719DAF26B0089068B /* com.lindegroup.AutoPkgr.helper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BE05CE7C19DAF5A30089068B /* LGAutoPkgrHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05CE7A19DAF5A30089068B /* LGAutoPkgrHelper.m */; };
@@ -185,6 +188,12 @@
 		BE025CF519BAE93400D36345 /* LGAutoPkgTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGAutoPkgTask.m; sourceTree = "<group>"; };
 		BE025CFC19BAEF8800D36345 /* LGAutoPkgSchedule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGAutoPkgSchedule.h; sourceTree = "<group>"; };
 		BE025CFD19BAEF8800D36345 /* LGAutoPkgSchedule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGAutoPkgSchedule.m; sourceTree = "<group>"; };
+		BE053D131A8F90920021D97B /* LGPasswords.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGPasswords.h; sourceTree = "<group>"; };
+		BE053D141A8F90920021D97B /* LGPasswords.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGPasswords.m; sourceTree = "<group>"; };
+		BE053D161A8F9DAA0021D97B /* SNTCodesignChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNTCodesignChecker.h; sourceTree = "<group>"; };
+		BE053D171A8F9DAA0021D97B /* SNTCodesignChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTCodesignChecker.m; sourceTree = "<group>"; };
+		BE053D191A8F9DC00021D97B /* SNTCertificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNTCertificate.h; sourceTree = "<group>"; };
+		BE053D1A1A8F9DC00021D97B /* SNTCertificate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SNTCertificate.m; sourceTree = "<group>"; };
 		BE05CE6719DAF26B0089068B /* com.lindegroup.AutoPkgr.helper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = com.lindegroup.AutoPkgr.helper; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE05CE6919DAF26B0089068B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		BE05CE7619DAF5A30089068B /* helper-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "helper-Info.plist"; sourceTree = "<group>"; };
@@ -453,6 +462,10 @@
 		BE05CE7D19DAF5B80089068B /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				BE053D191A8F9DC00021D97B /* SNTCertificate.h */,
+				BE053D1A1A8F9DC00021D97B /* SNTCertificate.m */,
+				BE053D161A8F9DAA0021D97B /* SNTCodesignChecker.h */,
+				BE053D171A8F9DAA0021D97B /* SNTCodesignChecker.m */,
 				BE05CE7619DAF5A30089068B /* helper-Info.plist */,
 				BE05CE7719DAF5A30089068B /* helper-Launchd.plist */,
 				BE05CE7819DAF5A30089068B /* helper-Prefix.pch */,
@@ -531,6 +544,8 @@
 				BE8C7D6D1A86CEF600EBD32A /* LGTools.m */,
 				BE0E857719D668F600B25B5E /* LGHTTPRequest.h */,
 				BE0E857819D668F600B25B5E /* LGHTTPRequest.m */,
+				BE053D131A8F90920021D97B /* LGPasswords.h */,
+				BE053D141A8F90920021D97B /* LGPasswords.m */,
 				1A1BAD94197A0407008192A7 /* LGVersionComparator.h */,
 				1A1BAD95197A0407008192A7 /* LGVersionComparator.m */,
 				BEBF7B151A4894AC00E9967F /* LGVersioner.h */,
@@ -824,6 +839,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE053D151A8F90920021D97B /* LGPasswords.m in Sources */,
 				BE0BACD11A2560AE00554989 /* LGJSSDistributionPointsPrefPanel.m in Sources */,
 				BEC1258919F046FA006696C4 /* main.m in Sources */,
 				BED02ADC1A194F9C00714CC2 /* NSArray+filtered.m in Sources */,
@@ -899,6 +915,8 @@
 				BE05CE9119DB380F0089068B /* LGConstants.m in Sources */,
 				BE1C810419E8224000EF77F3 /* NSImage+statusLight.m in Sources */,
 				BE05CE6A19DAF26B0089068B /* main.m in Sources */,
+				BE053D1B1A8F9DC00021D97B /* SNTCertificate.m in Sources */,
+				BE053D181A8F9DAA0021D97B /* SNTCodesignChecker.m in Sources */,
 				BE05CE7C19DAF5A30089068B /* LGAutoPkgrHelper.m in Sources */,
 				BE05CE8D19DB379C0089068B /* LGAutoPkgrAuthorizer.m in Sources */,
 				BE05CE9219DB38180089068B /* LGError.m in Sources */,

--- a/AutoPkgr/LGConfigurationWindowController.m
+++ b/AutoPkgr/LGConfigurationWindowController.m
@@ -29,10 +29,8 @@
 #import "LGAutoPkgSchedule.h"
 #import "LGProgressDelegate.h"
 #import "LGDisplayStatusDelegate.h"
-
 #import "LGTools.h"
-
-#import "AHKeychain.h"
+#import "LGPasswords.h"
 
 @interface LGConfigurationWindowController () {
     LGDefaults *_defaults;
@@ -59,6 +57,12 @@
 - (void)windowDidLoad
 {
     [super windowDidLoad];
+
+//    [LGPasswords migrateKeychainIfNeeded:^(NSString *password) {
+//        if (password) {
+//            _smtpPassword.stringValue = password;
+//        }
+//    }];
 
     // Populate the preference values from the user defaults, if they exist
     DLog(@"Populating configuration window settings based on user defaults, if they exist.");
@@ -119,13 +123,7 @@
     NSString *userName = _defaults.SMTPUsername;
     if (userName) {
         _smtpUsername.safeStringValue = userName;
-        NSString *password = [self getKeychainPassword];
-
-        // Only populate the SMTP Password field if the username exists
-        if (password) {
-            NSLog(@"Successfully retrieved keychain entry for account %@.", userName);
-            [_smtpPassword setStringValue:password];
-        }
+        [self getKeychainPassword:_smtpPassword];
     }
 
     // removeEmptyStrings is an NSArray category extension
@@ -252,50 +250,31 @@
 }
 
 #pragma mark - Keychain Actions
-- (NSString *)getKeychainPassword
+- (void)getKeychainPassword:(NSTextField *)sender
 {
-    NSError *error;
-    NSString *user = _smtpUsername.stringValue;
-
-    AHKeychain *keychain = [LGHostInfo appKeychain];
-    AHKeychainItem *item = [[AHKeychainItem alloc] init];
-    item.label = kLGApplicationName;
-    item.service = kLGAutoPkgrPreferenceDomain;
-    item.account = user;
-
-    [keychain getItem:item error:&error];
-
-    if ([error code] == errSecItemNotFound) {
-        NSLog(@"Keychain entry not found for account %@.", user);
-    } else if ([error code] == errSecNotAvailable) {
-        NSLog(@"Found the keychain entry for %@ but no password value was returned.", user);
-    } else if (error) {
-        NSLog(@"An error occurred when attempting to retrieve the keychain entry for %@. Error: %@", user, [error localizedDescription]);
+    NSString *account = _smtpUsername.stringValue;
+    if (account.length) {
+        [LGPasswords getPasswordForAccount:account reply:^(NSString *password, NSError *error) {
+            if (error) {
+                NSLog(@"Error getting password for %@ [%ld]: %@", account, error.code, error.localizedDescription);
+            } else {
+                sender.safeStringValue = password;
+            }
+        }];
     }
-
-    return item.password;
 }
 
 - (IBAction)updateKeychainPassword:(id)sender
 {
-    NSString *user = _smtpUsername.safeStringValue;
+    NSString *account = _smtpUsername.safeStringValue;
     NSString *password = _smtpPassword.safeStringValue;
 
-    if (user && password) {
-        NSError *error;
-
-        AHKeychain *keychain = [LGHostInfo appKeychain];
-        AHKeychainItem *item = [[AHKeychainItem alloc] init];
-
-        item.service = kLGAutoPkgrPreferenceDomain;
-        item.label = kLGApplicationName;
-        item.account = user;
-        item.password = password;
-
-        [keychain saveItem:item error:&error];
-        if (error) {
-            NSLog(@"Error setting password [%ld]: %@", error.code, error.localizedDescription);
-        }
+    if (account && password) {
+        [LGPasswords savePassword:password forAccount:account reply:^(NSError *error) {
+            if (error) {
+                NSLog(@"Error setting password [%ld]: %@", error.code, error.localizedDescription);
+            }
+        }];
     }
 }
 
@@ -719,7 +698,7 @@
         [self testSmtpServerPort:self];
     } else if ([object isEqual:_smtpUsername]) {
         _defaults.SMTPUsername = [_smtpUsername stringValue];
-        _smtpPassword.safeStringValue = [self getKeychainPassword];
+        [self getKeychainPassword:_smtpPassword];
     } else if ([object isEqual:_smtpFrom]) {
         _defaults.SMTPFrom = [_smtpFrom stringValue];
     } else if ([object isEqual:_localMunkiRepo]) {

--- a/AutoPkgr/LGHostInfo.m
+++ b/AutoPkgr/LGHostInfo.m
@@ -85,10 +85,10 @@
     BOOL success = YES;
     AHKeychain *keychain;
 
-    NSString *fullPath = [NSString stringWithFormat:@"%@/Library/Keychains/%@", NSHomeDirectory(), appKeychain];
+    NSString *keychainPath = [NSString stringWithFormat:@"%@/Library/Keychains/%@", NSHomeDirectory(), appKeychain];
     NSString *password = [[self class] macSerialNumber];
 
-    if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath]) {
+    if (![[NSFileManager defaultManager] fileExistsAtPath:keychainPath]) {
         keychain = [[AHKeychain alloc] initCreatingNewKeychain:appKeychain password:password];
         if (!keychain) {
             success = NO;

--- a/AutoPkgr/LGPasswords.h
+++ b/AutoPkgr/LGPasswords.h
@@ -1,0 +1,32 @@
+//
+//  LGPasswords.m
+//  AutoPkgr
+//
+//  Created by Eldon Ahrold on 2/14/15.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//
+
+
+#import <Foundation/Foundation.h>
+
+@interface LGPasswords : NSObject
+
++ (void)migrateKeychainIfNeeded:(void (^)(NSString *password))reply;
+
++ (void)getPasswordForAccount:(NSString *)account reply:(void (^)(NSString *password, NSError *error))reply;
+
++ (void)savePassword:(NSString *)password forAccount:(NSString *)account reply:(void (^)(NSError *error))reply;
+
+@end

--- a/AutoPkgr/LGPasswords.m
+++ b/AutoPkgr/LGPasswords.m
@@ -1,0 +1,118 @@
+//
+//  LGPasswords.m
+//  AutoPkgr
+//
+//  Created by Eldon Ahrold on 2/14/15.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//
+
+#import "LGPasswords.h"
+#import "LGAutoPkgrHelperConnection.h"
+#import "LGAutoPkgr.h"
+#import "AHKeychain.h"
+
+@implementation LGPasswords
+
++ (void)migrateKeychainIfNeeded:(void (^)(NSString *password))reply;
+{
+    NSError *error;
+
+    NSString *account = [[LGDefaults standardUserDefaults] SMTPUsername];
+    NSString *keychainPath = [@"~/Library/Keychains/AutoPkgr.keychain" stringByExpandingTildeInPath];
+    
+    NSFileManager *fm = [NSFileManager defaultManager];
+
+    if ([fm fileExistsAtPath:keychainPath]){
+        AHKeychain *keychain = [LGHostInfo appKeychain];
+
+        if (account) {
+            AHKeychainItem *item = [[AHKeychainItem alloc] init];
+            item.account = account;
+            item.service = kLGAutoPkgrPreferenceDomain;
+            item.label = kLGApplicationName;
+
+            if([keychain getItem:item error:&error]){
+                [[self class] savePassword:item.password forAccount:account reply:^(NSError *error) {
+                    if (error) {
+                        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+                            [self resetPasswordForAccount:account reply:reply];
+                        }];
+                    };
+                }];
+            }
+        }
+        [keychain deleteKeychain:&error];
+    }
+}
+
++ (void)getPasswordForAccount:(NSString *)account reply:(void (^)(NSString *, NSError *))reply
+{
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        LGAutoPkgrHelperConnection *helper = [LGAutoPkgrHelperConnection new];
+        [helper connectToHelper];
+
+        [[helper.connection remoteObjectProxyWithErrorHandler:^(NSError *error) {
+            reply(nil, error);
+            NSLog(@"%@", error.localizedDescription);
+        }] getPasswordForAccount:account
+         reply:reply];
+    }];
+};
+
++ (void)savePassword:(NSString *)password forAccount:(NSString *)account reply:(void (^)(NSError *))reply
+{
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        LGAutoPkgrHelperConnection *helper = [LGAutoPkgrHelperConnection new];
+        [helper connectToHelper];
+
+        [[helper.connection remoteObjectProxyWithErrorHandler:^(NSError *error) {
+            reply(error);
+            NSLog(@"%@", error.localizedDescription);
+        }] savePassword:password
+         forAccount:account
+         reply:reply];
+    }];
+}
+
+#pragma mark - Private
++ (void)resetPasswordForAccount:(NSString *)account reply:(void (^)(NSString *password))reply
+{
+    NSString *messageText = @"Error migrating password";
+    NSString *infoText = @"There was a problem migrating the password for %@, enter it here to update. You can also update it later in the preference window";
+
+    NSAlert *alert = [NSAlert alertWithMessageText:messageText
+                                     defaultButton:@"OK"
+                                   alternateButton:@"Cancel"
+                                       otherButton:nil
+                         informativeTextWithFormat:infoText, account];
+
+    NSSecureTextField *input = [[NSSecureTextField alloc] init];
+    [input setFrame:NSMakeRect(0, 0, 300, 24)];
+    [alert setAccessoryView:input];
+
+    NSInteger button = [alert runModal];
+    if (button == NSAlertDefaultReturn) {
+        [input validateEditing];
+        NSString *password = [input stringValue];
+        if (!password || [password isEqualToString:@""]) {
+            return [self resetPasswordForAccount:account reply:reply];
+        } else {
+            [[self class] savePassword:password forAccount:account reply:^(NSError *error) {
+                reply(password);
+            }];
+        }
+    }
+}
+@end

--- a/AutoPkgr/en.lproj/Credits.rtf
+++ b/AutoPkgr/en.lproj/Credits.rtf
@@ -56,10 +56,17 @@ following awesome open-source libraries:\
 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\qc
 
-\f1\b \cf0 SSKeychain
+\f1\b \cf0 AFNetworking
 \f0\b0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\qc
-{\field{\*\fldinst{HYPERLINK "https://github.com/soffes/sskeychain"}}{\fldrslt \cf0 https://github.com/soffes/sskeychain}}\
+{\field{\*\fldinst{HYPERLINK "https://github.com/soffes/sskeychain"}}{\fldrslt \cf0 https://github.com/AFNetworking/AFNetworking}}\
+\
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\qc
+
+\f1\b \cf0 SNTCodesignChecker
+\f0\b0 \
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\qc
+{\field{\*\fldinst{HYPERLINK "https://github.com/soffes/sskeychain"}}{\fldrslt \cf0 https://github.com/google/santa}}\
 \
 \
 \

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,7 @@ end
 
 target "com.lindegroup.AutoPkgr.helper" do
 pod 'AHLaunchCtl', '~> 0.3.1'
-pod 'AHCodesignVerifier', '~> 0.1'
+pod 'AHKeychain', '~> 0.2'
 end
 
 target "AutoPkgrTests" do
@@ -25,5 +25,4 @@ pod 'mailcore2-osx', '~> 0.5'
 pod 'AHProxySettings', '~> 0.1.1'
 pod 'AHKeychain', '~> 0.2'
 pod 'AHLaunchCtl', '~> 0.3.1'
-pod 'AHCodesignVerifier', '~> 0.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,7 +17,6 @@ PODS:
   - AFNetworking/Reachability (2.4.1)
   - AFNetworking/Security (2.4.1)
   - AFNetworking/Serialization (2.4.1)
-  - AHCodesignVerifier (0.1)
   - AHKeychain (0.2)
   - AHLaunchCtl (0.3.1)
   - AHProxySettings (0.1.1)
@@ -27,7 +26,6 @@ PODS:
 
 DEPENDENCIES:
   - AFNetworking (~> 2.4.1)
-  - AHCodesignVerifier (~> 0.1)
   - AHKeychain (~> 0.2)
   - AHLaunchCtl (~> 0.3.1)
   - AHProxySettings (~> 0.1.1)
@@ -37,7 +35,6 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   AFNetworking: 0aabc6fae66d6e5d039eeb21c315843c7aae51ab
-  AHCodesignVerifier: d85f1962a32cac1bf671f47f1ac015dcb45192f2
   AHKeychain: 8d76073b87a7d355ded1f03529a3088de4a9acf6
   AHLaunchCtl: cf2990d295737c020fa5cc890c65a8d414a33158
   AHProxySettings: 9237c332cf97cdd5c916b0203bbe19866ad4a615

--- a/helper/LGAutoPkgrHelper.m
+++ b/helper/LGAutoPkgrHelper.m
@@ -327,11 +327,11 @@ static const NSTimeInterval kHelperCheckInterval = 1.0; // how often to check wh
 {
     AHKeychainItem *item = [[AHKeychainItem alloc] init];
     item.account = account;
-    item.label = kLGApplicationName;
+    item.label = [kLGApplicationName stringByAppendingString:@" Email Password"];
 
     // Append the EUID to the service string to limit access
     // to only items created by the same user.
-    item.service = [kLGAutoPkgrPreferenceDomain stringByAppendingFormat:@"_%d", self.connection.effectiveUserIdentifier];
+    item.service = [item.label stringByAppendingFormat:@" UID: %d", self.connection.effectiveUserIdentifier];
     return item;
 }
 @end

--- a/helper/LGAutoPkgrProtocol.h
+++ b/helper/LGAutoPkgrProtocol.h
@@ -22,6 +22,12 @@
 #import "LGAutoPkgrAuthorizer.h"
 
 @protocol HelperAgent <NSObject>
+
+# pragma mark - Password
+- (void)getPasswordForAccount:(NSString *)account reply:(void (^)(NSString *password, NSError *error))reply;
+
+- (void)savePassword:(NSString *)password forAccount:(NSString *)account reply:(void (^)(NSError *error))reply;
+
 #pragma mark - Schedule
 #pragma mark-- Add
 - (void)scheduleRun:(NSInteger)interval
@@ -30,7 +36,8 @@
       authorization:(NSData *)authData
               reply:(void (^)(NSError *error))reply;
 
-#pragma mark-- Remove
+
+#pragma mark -- Remove
 - (void)removeScheduleWithAuthorization:(NSData *)authData
                                   reply:(void (^)(NSError *error))reply;
 

--- a/helper/SNTCertificate.h
+++ b/helper/SNTCertificate.h
@@ -1,0 +1,111 @@
+/// Copyright 2015 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+///
+///  SNTCertificate wraps a @c SecCertificateRef to provide Objective-C accessors to
+///  commonly used certificate data. Accessors cache data for repeated access.
+///
+@interface SNTCertificate : NSObject<NSSecureCoding>
+
+///
+///  Initialize a SNTCertificate object with a valid SecCertificateRef. Designated initializer.
+///
+///  @param certRef valid SecCertificateRef, which will be retained.
+///
+- (instancetype)initWithSecCertificateRef:(SecCertificateRef)certRef;
+
+///
+///  Initialize a SNTCertificate object with certificate data in DER format.
+///
+///  @param certData DER-encoded certificate data.
+///  @return initialized SNTCertificate or nil if certData is not a DER-encoded certificate.
+///
+- (instancetype)initWithCertificateDataDER:(NSData *)certData;
+
+///
+///  Initialize a SNTCertificate object with certificate data in PEM format.
+///  If multiple PEM certificates exist within the string, the first is used.
+///
+///  @param certData PEM-encoded certificate data.
+///  @return initialized SNTCertifcate or nil if certData is not a PEM-encoded certificate.
+///
+- (instancetype)initWithCertificateDataPEM:(NSString *)certData;
+
+///
+///  Returns an array of SNTCertificate's for all of the certificates in @c pemData.
+///
+///  @param pemData PEM-encoded certificates.
+///  @return array of SNTCertificate objects.
+///
++ (NSArray *)certificatesFromPEM:(NSString *)pemData;
+
+///
+///  Access the underlying certificate ref.
+///
+@property(readonly) SecCertificateRef certRef;
+
+///
+///  SHA-1 hash of the certificate data.
+///
+@property(readonly) NSString *SHA1;
+
+///
+///  SHA-256 hash of the certificate data.
+///
+@property(readonly) NSString *SHA256;
+
+///
+///  Certificate data.
+///
+@property(readonly) NSData *certData;
+
+///
+///  Common Name e.g: "Software Signing"
+///
+@property(readonly) NSString *commonName;
+
+///
+///  Country Name e.g: "US"
+///
+@property(readonly) NSString *countryName;
+
+///
+///  Organizational Name e.g: "Apple Inc."
+///
+@property(readonly) NSString *orgName;
+
+///
+///  Organizational Unit Name e.g: "Apple Software"
+///
+@property(readonly) NSString *orgUnit;
+
+///
+///  Issuer details, same fields as above.
+///
+@property(readonly) NSString *issuerCommonName;
+@property(readonly) NSString *issuerCountryName;
+@property(readonly) NSString *issuerOrgName;
+@property(readonly) NSString *issuerOrgUnit;
+
+///
+///  Validity Not Before
+///
+@property(readonly) NSDate *validFrom;
+
+///
+///  Validity Not After
+///
+@property(readonly) NSDate *validUntil;
+
+@end

--- a/helper/SNTCertificate.m
+++ b/helper/SNTCertificate.m
@@ -1,0 +1,363 @@
+/// Copyright 2015 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#import "SNTCertificate.h"
+
+#import <CommonCrypto/CommonDigest.h>
+#import <Security/Security.h>
+
+@interface SNTCertificate ()
+///
+///  A container for cached property values
+///
+@property NSMutableDictionary *memoizedData;
+@end
+
+@implementation SNTCertificate
+
+static NSString *const kCertDataKey = @"certData";
+
+#pragma mark Init/Dealloc
+
+- (instancetype)initWithSecCertificateRef:(SecCertificateRef)certRef {
+  self = [super init];
+  if (self) {
+    _certRef = certRef;
+    CFRetain(_certRef);
+  }
+  return self;
+}
+
+- (instancetype)initWithCertificateDataDER:(NSData *)certData {
+  SecCertificateRef cert = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certData);
+
+  if (cert) {
+    // Despite the header file claiming that SecCertificateCreateWithData will return NULL if
+    // @c certData doesn't contain a valid DER-encoded X509 cert, this isn't always true.
+    // radar://problem/16124651
+    // To workaround, check that the certificate serial number can be retrieved.
+    NSData *ser = CFBridgingRelease(SecCertificateCopySerialNumber(cert, NULL));
+    if (ser) {
+      self = [self initWithSecCertificateRef:cert];
+    } else {
+      self = nil;
+    }
+    CFRelease(cert);  // was retained in initWithSecCertificateRef
+  } else {
+    self = nil;
+  }
+
+  return self;
+}
+
+- (instancetype)initWithCertificateDataPEM:(NSString *)certData {
+  // Find the PEM and extract the base64-encoded DER data from within
+  NSScanner *scanner = [NSScanner scannerWithString:certData];
+  NSString *base64der;
+
+  // Locate and parse DER data into |base64der|
+  [scanner scanUpToString:@"-----BEGIN CERTIFICATE-----" intoString:NULL];
+  if (!([scanner scanString:@"-----BEGIN CERTIFICATE-----" intoString:NULL] &&
+        [scanner scanUpToString:@"-----END CERTIFICATE-----" intoString:&base64der] &&
+        [scanner scanString:@"-----END CERTIFICATE-----" intoString:NULL])) {
+    return nil;
+  }
+
+  // base64-decode the DER
+  SecTransformRef transform = SecDecodeTransformCreate(kSecBase64Encoding, NULL);
+  if (!transform) return nil;
+  NSData *input = [base64der dataUsingEncoding:NSUTF8StringEncoding];
+  NSData *output = nil;
+
+  if (SecTransformSetAttribute(transform,
+                             kSecTransformInputAttributeName,
+                             (__bridge CFDataRef)input,
+                             NULL)) {
+    output = CFBridgingRelease(SecTransformExecute(transform, NULL));
+  }
+  if (transform) CFRelease(transform);
+
+  return [self initWithCertificateDataDER:output];
+}
+
++ (NSArray *)certificatesFromPEM:(NSString *)pemData {
+  NSScanner *scanner = [NSScanner scannerWithString:pemData];
+  NSMutableArray *certs = [[NSMutableArray alloc] init];
+
+  while (YES) {
+    NSString *curCert;
+
+    [scanner scanUpToString:@"-----BEGIN CERTIFICATE-----" intoString:NULL];
+    [scanner scanUpToString:@"-----END CERTIFICATE-----" intoString:&curCert];
+
+    // If there was no data, break.
+    if (!curCert) break;
+
+    curCert = [curCert stringByAppendingString:@"-----END CERTIFICATE-----"];
+    SNTCertificate *cert = [[SNTCertificate alloc] initWithCertificateDataPEM:curCert];
+
+    // If the data couldn't be turned into a valid SNTCertificate, continue.
+    if (!cert) continue;
+
+    [certs addObject:cert];
+  }
+
+  return certs;
+}
+
+- (instancetype)init {
+  [self doesNotRecognizeSelector:_cmd];
+  return nil;
+}
+
+- (void)dealloc {
+  if (_certRef) CFRelease(_certRef);
+}
+
+#pragma mark Equality & description
+
+- (BOOL)isEqual:(SNTCertificate *)other {
+  if (self == other) return YES;
+  if (![other isKindOfClass:[SNTCertificate class]]) return NO;
+
+  return [self.certData isEqual:other.certData];
+}
+
+- (NSUInteger)hash {
+  return [self.certData hash];
+}
+
+- (NSString *)description {
+  return [NSString stringWithFormat:@"/O=%@/OU=%@/CN=%@",
+          self.orgName,
+          self.orgUnit,
+          self.commonName];
+}
+
+#pragma mark NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+  [coder encodeObject:self.certData forKey:kCertDataKey];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+  NSData *certData = [decoder decodeObjectOfClass:[NSData class] forKey:kCertDataKey];
+  if ([certData length] == 0) return nil;
+  SecCertificateRef cert = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certData);
+  self = [self initWithSecCertificateRef:cert];
+  if (cert) CFRelease(cert);
+  return self;
+}
+
+#pragma mark Private Accessors
+
+///
+/// For a given selector, caches the value that selector would return on subsequent invocations,
+/// using the provided block to get the value on the first invocation.
+/// Assumes the selector's value will never change.
+///
+- (id)memoizedSelector:(SEL)selector forBlock:(id (^)(void))block {
+  NSString *selName = NSStringFromSelector(selector);
+
+  if (!self.memoizedData) {
+    self.memoizedData = [NSMutableDictionary dictionary];
+  }
+
+  if (!self.memoizedData[selName]) {
+    id val = block();
+    if (val) {
+      self.memoizedData[selName] = val;
+    } else {
+      self.memoizedData[selName] = [NSNull null];
+    }
+  }
+
+  // Return the value if there is one, or nil if the value is NSNull
+  return self.memoizedData[selName] != [NSNull null] ? self.memoizedData[selName] : nil;
+}
+
+- (NSDictionary *)allCertificateValues {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return CFBridgingRelease(SecCertificateCopyValues(self.certRef, NULL, NULL));
+  }];
+}
+
+- (NSDictionary *)x509SubjectName {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self allCertificateValues][(__bridge NSString *)kSecOIDX509V1SubjectName];
+  }];
+}
+
+- (NSDictionary *)x509IssuerName {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self allCertificateValues][(__bridge NSString *)kSecOIDX509V1IssuerName];
+  }];
+}
+
+///
+///  Retrieve the value with the specified label from the X509 dictionary provided
+///
+///  @param desiredLabel The label you want, e.g: kSecOIDOrganizationName.
+///  @param dict The dictionary to look in (Subject or Issuer)
+///  @return An @c NSString, the value for the specified label.
+///
+- (NSString *)x509ValueForLabel:(NSString *)desiredLabel fromDictionary:(NSDictionary *)dict {
+  @try {
+    NSArray *valArray = dict[(__bridge NSString *)kSecPropertyKeyValue];
+
+    for (NSDictionary *curCertVal in valArray) {
+      NSString *valueLabel = curCertVal[(__bridge NSString *)kSecPropertyKeyLabel];
+      if ([valueLabel isEqual:desiredLabel]) {
+        return curCertVal[(__bridge NSString *)kSecPropertyKeyValue];
+      }
+    }
+    return nil;
+  }
+  @catch (NSException *exception) {
+    return nil;
+  }
+}
+
+///
+/// Retrieve the specified date from the certificate's values and convert from a reference date
+/// to an NSDate object.
+///
+/// @param key The identifier for the date: @c kSecOIDX509V1ValiditityNot{Before,After}
+/// @return An @c NSDate representing the date and time the certificate is valid from or expires.
+///
+- (NSDate *)dateForX509Key:(NSString *)key {
+  NSDictionary *curCertVal = [self allCertificateValues][key];
+  NSNumber *value = curCertVal[(__bridge NSString *)kSecPropertyKeyValue];
+
+  NSTimeInterval interval = [value doubleValue];
+  if (interval) {
+    return [NSDate dateWithTimeIntervalSinceReferenceDate:interval];
+  }
+
+  return nil;
+}
+
+#pragma mark Public Accessors
+
+- (NSString *)SHA1 {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      NSMutableData *SHA1Buffer = [[NSMutableData alloc] initWithCapacity:CC_SHA1_DIGEST_LENGTH];
+
+      CC_SHA1([self.certData bytes], (CC_LONG)[self.certData length], [SHA1Buffer mutableBytes]);
+
+    const unsigned char *bytes = (const unsigned char *)[SHA1Buffer bytes];
+    NSMutableString *hexDigest = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) {
+      [hexDigest appendFormat:@"%02x", bytes[i]];
+    }
+
+    return hexDigest;
+  }];
+}
+
+- (NSString *)SHA256 {
+  return [self memoizedSelector:_cmd forBlock:^id{
+    NSMutableData *SHA256Buffer = [[NSMutableData alloc] initWithCapacity:CC_SHA256_DIGEST_LENGTH];
+
+    CC_SHA256([self.certData bytes], (CC_LONG)[self.certData length], [SHA256Buffer mutableBytes]);
+
+    const unsigned char *bytes = (const unsigned char *)[SHA256Buffer bytes];
+    NSMutableString *hexDigest = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+      [hexDigest appendFormat:@"%02x", bytes[i]];
+    }
+
+    return hexDigest;
+  }];
+}
+
+- (NSData *)certData {
+  return CFBridgingRelease(SecCertificateCopyData(self.certRef));
+}
+
+- (NSString *)commonName {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      CFStringRef commonName = NULL;
+      SecCertificateCopyCommonName(self.certRef, &commonName);
+      return CFBridgingRelease(commonName);
+  }];
+}
+
+- (NSString *)countryName {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self x509ValueForLabel:(__bridge NSString *)kSecOIDCountryName
+                      fromDictionary:[self x509SubjectName]];
+  }];
+}
+
+- (NSString *)orgName {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self x509ValueForLabel:(__bridge NSString *)kSecOIDOrganizationName
+                      fromDictionary:[self x509SubjectName]];
+  }];
+}
+
+- (NSString *)orgUnit {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self x509ValueForLabel:(__bridge NSString *)kSecOIDOrganizationalUnitName
+                      fromDictionary:[self x509SubjectName]];
+  }];
+}
+
+- (NSDate *)validFrom {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self dateForX509Key:(__bridge NSString *)kSecOIDX509V1ValidityNotBefore];
+  }];
+}
+
+- (NSDate *)validUntil {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self dateForX509Key:(__bridge NSString *)kSecOIDX509V1ValidityNotAfter];
+  }];
+}
+
+- (NSString *)issuerCommonName {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self x509ValueForLabel:(__bridge NSString *)kSecOIDCommonName
+                      fromDictionary:[self x509IssuerName]];
+  }];
+}
+
+- (NSString *)issuerCountryName {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self x509ValueForLabel:(__bridge NSString *)kSecOIDCountryName
+                      fromDictionary:[self x509IssuerName]];
+  }];
+}
+
+- (NSString *)issuerOrgName {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self x509ValueForLabel:(__bridge NSString *)kSecOIDOrganizationName
+                      fromDictionary:[self x509IssuerName]];
+  }];
+}
+
+- (NSString *)issuerOrgUnit {
+  return [self memoizedSelector:_cmd forBlock:^id{
+      return [self x509ValueForLabel:(__bridge NSString *)kSecOIDOrganizationalUnitName
+                      fromDictionary:[self x509IssuerName]];
+  }];
+}
+
+
+@end

--- a/helper/SNTCodesignChecker.h
+++ b/helper/SNTCodesignChecker.h
@@ -1,0 +1,90 @@
+/// Copyright 2015 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+@class SNTCertificate;
+
+///
+///  SNTCodesignChecker validates a binary (either on-disk or in memory) has been signed
+///  and if so allows for pulling out the certificates that were used to sign it.
+///
+@interface SNTCodesignChecker : NSObject
+
+///
+///  The SecStaticCodeRef that this SNTCodesignChecker is working around
+///
+@property(readonly) SecStaticCodeRef codeRef;
+
+///
+///  Returns a dictionary of raw signing information
+///
+@property(readonly) NSDictionary *signingInformation;
+
+///
+///  Returns an array of @c SNTCertificate objects representing the chain that signed this binary.
+///
+@property(readonly) NSArray *certificates;
+
+///
+///  Returns the leaf certificate that this binary was signed with
+///
+@property(readonly) SNTCertificate *leafCertificate;
+
+///
+///  Returns the on-disk path of this binary.
+///
+@property(readonly) NSString *binaryPath;
+
+///
+///  Designated initializer
+///  Takes ownership of the codeRef reference.
+///
+///  @param codeRef a SecStaticCodeRef or SecCodeRef representing a binary.
+///  @return an initialized SNTCodesignChecker if the binary is validly signed, nil otherwise.
+///
+- (instancetype)initWithSecStaticCodeRef:(SecStaticCodeRef)codeRef;
+
+///
+///  Convenience initializer for a binary on disk.
+///
+///  @param binaryPath A binary file on disk
+///  @return an initialized SNTCodesignChecker if file is a binary and is signed, nil otherwise.
+///
+- (instancetype)initWithBinaryPath:(NSString *)binaryPath;
+
+///
+///  Convenience initializer for a binary that is running, by its process ID.
+///
+///  @param PID Id of a running process.
+///  @return an initialized SNTCodesignChecker if binary is signed, nil otherwise.
+///
+- (instancetype)initWithPID:(pid_t)PID;
+
+///
+///  Convenience initializer for the currently running process.
+///
+///  @return an initialized SNTCodesignChecker if current binary is signed, nil otherwise.
+///
+- (instancetype)initWithSelf;
+
+///
+///  Compares the signatures of the binaries represented by this SNTCodesignChecker and
+///  @c otherChecker.
+///
+///  If both binaries are correctly signed and the leaf signatures are identical.
+///
+///  @return YES if both binaries are signed with the same leaf certificate.
+///
+- (BOOL)signingInformationMatches:(SNTCodesignChecker *)otherChecker;
+
+@end

--- a/helper/SNTCodesignChecker.m
+++ b/helper/SNTCodesignChecker.m
@@ -1,0 +1,199 @@
+/// Copyright 2015 Google Inc. All rights reserved.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+///    Unless required by applicable law or agreed to in writing, software
+///    distributed under the License is distributed on an "AS IS" BASIS,
+///    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+///    See the License for the specific language governing permissions and
+///    limitations under the License.
+
+#import "SNTCodesignChecker.h"
+
+#import <Security/Security.h>
+
+#import "SNTCertificate.h"
+
+
+/**
+ *  kStaticSigningFlags are the flags used when validating signatures on disk.
+ *
+ *  Don't validate resources but do validate nested code. Ignoring resources _dramatically_ speeds
+ *  up validation (see below) but does mean images, plists, etc will not be checked and modifying
+ *  these will not be considered invalid. To ensure any code inside the binary is still checked,
+ *  we check nested code.
+ *
+ *  Timings with different flags:
+ *    Checking Xcode 5.1.1 bundle:
+ *       kSecCSDefaultFlags:                                   3.895s
+ *       kSecCSDoNotValidateResources:                         0.013s
+ *       kSecCSDoNotValidateResources | kSecCSCheckNestedCode: 0.013s
+ *
+ *    Checking Google Chrome 36.0.1985.143 bundle:
+ *       kSecCSDefaultFlags:                                   0.529s
+ *       kSecCSDoNotValidateResources:                         0.032s
+ *       kSecCSDoNotValidateResources | kSecCSCheckNestedCode: 0.033s
+ */
+const SecCSFlags kStaticSigningFlags = kSecCSDoNotValidateResources | kSecCSCheckNestedCode;
+
+/**
+ *  kSigningFlags are the flags used when validating signatures for running binaries.
+ *
+ *  No special flags needed currently.
+ */
+const SecCSFlags kSigningFlags = kSecCSDefaultFlags;
+
+
+@interface SNTCodesignChecker ()
+/// Array of @c SNTCertificate's representing the chain of certs this executable was signed with.
+@property NSMutableArray *certificates;
+@end
+
+@implementation SNTCodesignChecker
+
+#pragma mark Init/dealloc
+
+- (instancetype)initWithSecStaticCodeRef:(SecStaticCodeRef)codeRef {
+  self = [super init];
+
+  if (self) {
+    // First check the signing is valid
+    if (CFGetTypeID(codeRef) == SecStaticCodeGetTypeID()) {
+      if (SecStaticCodeCheckValidity(codeRef, kStaticSigningFlags, NULL) != errSecSuccess) {
+        return nil;
+      }
+    } else if (CFGetTypeID(codeRef) == SecCodeGetTypeID()) {
+      if (SecCodeCheckValidity((SecCodeRef)codeRef, kSigningFlags, NULL) != errSecSuccess) {
+        return nil;
+      }
+    } else {
+      return nil;
+    }
+
+    // Get CFDictionary of signing information for binary
+    OSStatus status = errSecSuccess;
+    CFDictionaryRef signingDict = NULL;
+    status = SecCodeCopySigningInformation(codeRef, kSecCSSigningInformation, &signingDict);
+    _signingInformation = CFBridgingRelease(signingDict);
+    if (status != errSecSuccess) return nil;
+
+    // Get array of certificates.
+    NSArray *certs = _signingInformation[(id)kSecCodeInfoCertificates];
+    if (!certs) return nil;
+
+    // Wrap SecCertificateRef objects in SNTCertificate and put in a new NSArray
+    NSMutableArray *mutableCerts = [[NSMutableArray alloc] initWithCapacity:certs.count];
+    for (int i = 0; i < certs.count; ++i) {
+      SecCertificateRef certRef = (__bridge SecCertificateRef)certs[i];
+      SNTCertificate *newCert = [[SNTCertificate alloc] initWithSecCertificateRef:certRef];
+      [mutableCerts addObject:newCert];
+    }
+    _certificates = [mutableCerts copy];
+
+    _codeRef = codeRef;
+    CFRetain(_codeRef);
+  }
+
+  return self;
+}
+
+- (instancetype)initWithBinaryPath:(NSString *)binaryPath {
+  SecStaticCodeRef codeRef = NULL;
+
+  // Get SecStaticCodeRef for binary
+  if (SecStaticCodeCreateWithPath((__bridge CFURLRef)[NSURL fileURLWithPath:binaryPath
+                                                                isDirectory:NO],
+                                  kSecCSDefaultFlags,
+                                  &codeRef) == errSecSuccess) {
+    self = [self initWithSecStaticCodeRef:codeRef];
+  } else {
+    self = nil;
+  }
+
+  if (codeRef) CFRelease(codeRef);
+  return self;
+}
+
+- (instancetype)initWithPID:(pid_t)PID {
+  SecCodeRef codeRef = NULL;
+  NSDictionary *attributes = @{(__bridge NSString *)kSecGuestAttributePid: @(PID)};
+
+  if (SecCodeCopyGuestWithAttributes(NULL,
+                                     (__bridge CFDictionaryRef)attributes,
+                                     kSecCSDefaultFlags,
+                                     &codeRef) == errSecSuccess) {
+    self = [self initWithSecStaticCodeRef:codeRef];
+  } else {
+    self = nil;
+  }
+
+  if (codeRef) CFRelease(codeRef);
+  return self;
+}
+
+- (instancetype)initWithSelf {
+  SecCodeRef codeSelf = NULL;
+  if (SecCodeCopySelf(kSecCSDefaultFlags, &codeSelf) == errSecSuccess) {
+    self = [self initWithSecStaticCodeRef:codeSelf];
+  } else {
+    self = nil;
+  }
+
+  if (codeSelf) CFRelease(codeSelf);
+  return self;
+}
+
+- (instancetype)init {
+  [self doesNotRecognizeSelector:_cmd];
+  return nil;
+}
+
+- (void)dealloc {
+  if (_codeRef) {
+    CFRelease(_codeRef);
+    _codeRef = NULL;
+  }
+}
+
+#pragma mark Description
+
+- (NSString *)description {
+  NSString *binarySource;
+  if (CFGetTypeID(self.codeRef) == SecStaticCodeGetTypeID()) {
+    binarySource = @"On-disk";
+  } else {
+    binarySource = @"In-memory";
+  }
+
+  return [NSString stringWithFormat:@"%@ binary, signed by %@, located at: %@",
+             binarySource,
+             self.leafCertificate.orgName,
+             self.binaryPath];
+}
+
+#pragma mark Public accessors
+
+- (SNTCertificate *)leafCertificate {
+  return [self.certificates firstObject];
+}
+
+- (NSString *)binaryPath {
+  CFURLRef path;
+  OSStatus status = SecCodeCopyPath(_codeRef, kSecCSDefaultFlags, &path);
+  NSURL *pathURL = CFBridgingRelease(path);
+  if (status != errSecSuccess) return nil;
+  return [pathURL path];
+}
+
+- (BOOL)signingInformationMatches:(SNTCodesignChecker *)otherChecker {
+    if (self.certificates && otherChecker.certificates) {
+        return [self.certificates isEqual:otherChecker.certificates];
+    }
+    return NO;
+}
+
+@end

--- a/helper/helper-Info.plist
+++ b/helper/helper-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>com.lindegroup.AutoPkgr.helper</string>
 	<key>CFBundleVersion</key>
-	<string>1.2.2</string>
+	<string>1.2.3</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>identifier "com.lindegroup.AutoPkgr" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JVY2ZR6SEF</string>


### PR DESCRIPTION
For Discussion see	#271 
        -- Remove AHCodeSignVerifier, start using SNTCodesignChecker.
	-- All NSXPCConnections now check that AutoPkgr is making the call.
	-- Added LGPasswords class.
	-- Migrate password method is currently commented out, see [L61-L65 of LGConfigurationWindowController](https://github.com/lindegroup/autopkgr/blob/75964f3a6f904b3340cad5348bc964a2c34db2be/AutoPkgr/LGConfigurationWindowController.m#L61-L65)
	-- Update credits