### PR TITLE
Fix duplicate keys in environment. Fixes #284 #291.

### DIFF
--- a/AutoPkgr/main.m
+++ b/AutoPkgr/main.m
@@ -24,6 +24,7 @@
 #import "LGRecipes.h"
 #import "LGEmailer.h"
 #import "LGAutoPkgr.h"
+#import <crt_externs.h>
 
 void postUpdateMessage(NSString *message, double progress, BOOL complete)
 {
@@ -63,8 +64,92 @@ void hardSyncPreferences()
 }
 
 
+void fixYosemiteDuplicateEnvKeys(){
+    // Since this seems to be a Yosemite‎
+    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber10_9_2) {
+        DLog(@"Checking for duplicate env keys...");
+        // This fix is attributed to http://tex.stackexchange.com/a/208182
+
+        // http://lists.apple.com/archives/cocoa-dev/2011/Jan/msg00169.html
+        signal(SIGPIPE, SIG_IGN);
+
+        char ***original_env = _NSGetEnviron();
+        unsigned int idx, original_count = 0;
+        char **env = *original_env;
+
+        // count items in the original environment
+        while (NULL != *env) {
+            original_count++;
+            env++;
+        }
+
+        /*
+         Make a copy of the environment, but don't worry about
+         NULL-terminating this array; we'll access it by index.
+         */
+        char **new_env = calloc(original_count, sizeof(char *));
+        env = *original_env;
+        for (idx = 0; idx < original_count; idx++)
+            new_env[idx] = strdup(env[idx]);
+
+        /*
+         This should be only half the length of the original
+         environment, as long as we have this bug.
+         */
+        char **keys_seen = calloc(original_count, sizeof(char *));
+        unsigned number_of_keys_seen = 0;
+
+        // iterate our copy of environ, not the original
+        for (idx = 0; idx < original_count; idx++) {
+
+            char *key, *value = new_env[idx];
+            key = strsep(&value, "=");
+
+            if (NULL != key && NULL != value) {
+
+                bool duplicate_key = false;
+                unsigned sidx;
+                /*
+                 A linear search is okay, since the number of keys is small
+                 and this is a one-time cost.
+                 */
+                for (sidx = 0; sidx < number_of_keys_seen; sidx++) {
+
+                    if (strcmp(key, keys_seen[sidx]) == 0) {
+                        duplicate_key = true;
+                        break;
+                    }
+                }
+
+                if (false == duplicate_key) {
+                    (void) unsetenv(key);
+                    setenv(key, value, 1);
+                    keys_seen[number_of_keys_seen] = strdup(key);
+                    number_of_keys_seen++;
+                } else {
+                    NSLog(@"[OSX 10.10 BUG] Found a duplicate env key %s = %s", key, value );
+                }
+            }
+
+            // strdup'ed, and we're not using it again
+            free(new_env[idx]);
+
+        }
+
+        free(new_env);
+
+        // free each of these strdup'ed keys
+        for (idx = 0; idx < number_of_keys_seen; idx++)
+            free(keys_seen[idx]);
+        free(keys_seen);
+    }
+}
+
+
 int main(int argc, const char *argv[])
 {
+
+    fixYosemiteDuplicateEnvKeys();
     NSUserDefaults *args = [NSUserDefaults standardUserDefaults];
 
     if ([args boolForKey:@"runInBackground"]) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file. This projec
 - Fixed a bug that prevented autopkg run status from appearing in the menu.
 - Made configuration options for "Run AutoPkg Now" consistent with menu items.
 - Fixed a situation that prevented launchd from reading current defaults values. (#296)
+- Fixes a condition where there are duplicate environment keys set in Yosemite (#284, #291)
 
 ### Changed
 - Uninstall is now handled by the main app, not the helper tool.


### PR DESCRIPTION
This is a fix with two verified successes. But it really tinkers with the app's internals, so I'm a little bit nervous without some more extensive testing.

It is set-up to _only_ manipulate Yosemite, so it really won't need too much scrutiny on Mav and ML.

If we don't get it into 1.2.1, we can always include it on the next go-around.