### PR TITLE
Better cfprefsd fix

### DIFF
--- a/AutoPkgr/LGAppDelegate.m
+++ b/AutoPkgr/LGAppDelegate.m
@@ -75,11 +75,6 @@
     NSLog(@"Welcome to AutoPkgr!");
     DLog(@"Verbose logging is active. To deactivate, option-click the AutoPkgr menu icon and uncheck Verbose Logs.");
 
-    // Start observing distributed notifications for background runs
-    [[NSDistributedNotificationCenter defaultCenter] addObserver:self
-                                                        selector:@selector(didReceiveStatusUpdate:)
-                                                            name:kLGNotificationProgressMessageUpdate
-                                                          object:nil];
     // Setup the status item
     [self setupStatusItem];
 
@@ -94,6 +89,18 @@
             [[NSApplication sharedApplication] terminate:self];
         }
     }
+
+    // Register to get background progress updates...
+    LGAutoPkgrHelperConnection *backgroundMonitor = [LGAutoPkgrHelperConnection new];
+
+    [backgroundMonitor connectToHelper];
+    backgroundMonitor.connection.exportedObject = self;
+    backgroundMonitor.connection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(LGProgressDelegate)];
+
+    [[backgroundMonitor.connection remoteObjectProxy] registerMainApplication:^(BOOL resign) {
+        DLog(@"No longer monitoring scheduled autopkg run");
+    }];
+
 
     if (![LGRecipes migrateToIdentifiers:nil]) {
         [NSApp presentError:[NSError errorWithDomain:kLGApplicationName code:-1 userInfo:@{ NSLocalizedDescriptionKey : @"AutoPkgr will now quit.",
@@ -267,27 +274,6 @@
 }
 
 #pragma mark - Progress Protocol
-- (void)didReceiveStatusUpdate:(NSNotification *)aNotification
-{
-    NSDictionary *info = aNotification.userInfo;
-    NSString *message = info[kLGNotificationUserInfoMessage];
-
-    if (!_initialMessageFromBackgroundRunProcessed) {
-        _configurationWindowInitiallyVisible = [_configurationWindowController.window isVisible];
-        if (_configurationWindowController && _configurationWindowInitiallyVisible) {
-            [_configurationWindowController startProgressWithMessage:@"Performing AutoPkg background run."];
-        }
-        _initialMessageFromBackgroundRunProcessed = YES;
-    }
-
-    if ([info[kLGNotificationUserInfoSuccess] boolValue]) {
-        [self stopProgress:nil];
-    } else {
-        double progress = [info[kLGNotificationUserInfoProgress] doubleValue];
-        [self updateProgress:message progress:progress];
-    }
-}
-
 - (void)startProgressWithMessage:(NSString *)message
 {
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{

--- a/AutoPkgr/LGAppDelegate.m
+++ b/AutoPkgr/LGAppDelegate.m
@@ -400,6 +400,21 @@
 }
 
 #pragma mark - Menu Delegate
+- (void)menuWillOpen:(NSMenu *)menu
+{
+    // The preferences set via the background run are not picked up
+    // despite aggressive synchronization, so we need to pull the value from
+    // the actual preference file until a better work around is found...
+
+    NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:[@"~/Library/Preferences/com.lindegroup.AutoPkgr.plist" stringByExpandingTildeInPath]];
+
+    NSString *date = dict[@"LastAutoPkgRun"];
+    if (date) {
+        NSString *status = [NSString stringWithFormat:@"Last AutoPkg Run: %@", date ?: @"Never by AutoPkgr"];
+        [_progressMenuItem setTitle:status];
+    }
+}
+
 - (void)menuDidClose:(NSMenu *)menu
 {
     self.statusItem.image = [NSImage imageNamed:@"autopkgr.png"];

--- a/AutoPkgr/LGDefaults.m
+++ b/AutoPkgr/LGDefaults.m
@@ -114,24 +114,23 @@
 #pragma mark - Info
 - (id)LastAutoPkgRun
 {
-    id date = [self objectForKey:NSStringFromSelector(@selector(LastAutoPkgRun))];
-    NSString *retVal = @"";
-    if ([date isKindOfClass:[NSDate class]]) {
-        NSDateFormatter *fomatter = [NSDateFormatter new];
-        [fomatter setDateStyle:NSDateFormatterMediumStyle];
-        [fomatter setTimeStyle:NSDateFormatterMediumStyle];
-        retVal = [fomatter stringFromDate:date];
-    } else if ([date isKindOfClass:[NSString class]]){
-        retVal = date;
-    }
-    return retVal;
+    return [self objectForKey:NSStringFromSelector(@selector(LastAutoPkgRun))];
 }
 
 - (void)setLastAutoPkgRun:(id)LastAutoPkgRun
 {
-    if ([LastAutoPkgRun isKindOfClass:[NSDate class]] || [LastAutoPkgRun isKindOfClass:[NSString class]] ) {
-        [self setObject:LastAutoPkgRun forKey:NSStringFromSelector(@selector(LastAutoPkgRun))];
+    NSString *setVal;
+    if ([LastAutoPkgRun isKindOfClass:[NSDate class]]){
+        NSDateFormatter *fomatter = [NSDateFormatter new];
+        [fomatter setDateStyle:NSDateFormatterMediumStyle];
+        [fomatter setTimeStyle:NSDateFormatterMediumStyle];
+        setVal = [fomatter stringFromDate:LastAutoPkgRun];
+    } else if ([LastAutoPkgRun isKindOfClass:[NSString class]] ) {
+        setVal = LastAutoPkgRun;
+        NSLog(@"Setting date as string");
     }
+    
+    [self setObject:setVal forKey:NSStringFromSelector(@selector(LastAutoPkgRun))];
 }
 
 #pragma mark - BOOL

--- a/AutoPkgr/main.m
+++ b/AutoPkgr/main.m
@@ -32,48 +32,20 @@ void postUpdateMessage(NSString *message, double progress, BOOL complete)
                       object:nil
                     userInfo:@{ kLGNotificationUserInfoMessage : message ?: @"",
                                 kLGNotificationUserInfoProgress : @(progress),
-                                kLGNotificationUserInfoSuccess : @(complete) }];
+                                kLGNotificationUserInfoSuccess : @(complete) }
+          deliverImmediately:complete];
 }
-
-void hardSyncPreferences()
-{
-    // This is an extremely ugly hack, but for some reason, cfprefsd is not
-    // reliably picking up changes when the background run is executed by launchd.
-    // We're stuck syncing directly from the file.
-    //
-    // Only ever run this for the background run!!!
-
-    // Hard sync AutoPkgr
-    NSDictionary *autoPkgrDict = [NSDictionary dictionaryWithContentsOfFile:[@"~/Library/Preferences/com.lindegroup.AutoPkgr.plist" stringByExpandingTildeInPath]];
-
-    CFPreferencesSetMultiple((__bridge CFDictionaryRef)autoPkgrDict,
-                             NULL,
-                             kCFPreferencesCurrentApplication,
-                             kCFPreferencesCurrentUser,
-                             kCFPreferencesAnyHost);
-
-    // Hard sync AutoPkg
-    NSDictionary *autoPkgDict = [NSDictionary dictionaryWithContentsOfFile:[@"~/Library/Preferences/com.github.autopkg.plist" stringByExpandingTildeInPath]];
-
-    CFPreferencesSetMultiple((__bridge CFDictionaryRef)autoPkgDict,
-                             NULL,
-                             (__bridge CFStringRef)(kLGAutoPkgPreferenceDomain),
-                             kCFPreferencesCurrentUser,
-                             kCFPreferencesAnyHost);
-}
-
 
 int main(int argc, const char *argv[])
 {
     NSUserDefaults *args = [NSUserDefaults standardUserDefaults];
 
     if ([args boolForKey:@"runInBackground"]) {
-        hardSyncPreferences();
         NSLog(@"Running AutoPkgr in background...");
 
         __block LGEmailer *emailer = [[LGEmailer alloc] init];
 
-        BOOL update =  [args boolForKey:kLGCheckForRepoUpdatesAutomaticallyEnabled];
+        BOOL update = [args boolForKey:kLGCheckForRepoUpdatesAutomaticallyEnabled];
 
         LGAutoPkgTaskManager *manager = [[LGAutoPkgTaskManager alloc] init];
 
@@ -94,7 +66,7 @@ int main(int argc, const char *argv[])
 
         NSLog(@"AutoPkg background run complete.");
         return 0;
-        
+
     } else {
         return NSApplicationMain(argc, argv);
     }

--- a/helper/LGAutoPkgrHelper.m
+++ b/helper/LGAutoPkgrHelper.m
@@ -287,6 +287,7 @@ helper_reply:
             job.StartInterval = timer;
             job.SessionCreate = YES;
             job.UserName = user;
+            job.EnvironmentVariables = @{@"__CFPREFERENCES_AVOID_DAEMON" : @"1"};
 
             [[AHLaunchCtl sharedController] add:job toDomain:kAHGlobalLaunchDaemon error:&error];
         }

--- a/helper/LGAutoPkgrHelper.m
+++ b/helper/LGAutoPkgrHelper.m
@@ -37,12 +37,16 @@ static const NSTimeInterval kHelperCheckInterval = 1.0; // how often to check wh
 
 @interface LGAutoPkgrHelper () <HelperAgent, NSXPCListenerDelegate>
 @property (atomic, strong, readwrite) NSXPCListener *listener;
-@property (weak) NSXPCConnection *connection;
-@property (strong, nonatomic) NSMutableSet *connections;
+@property (readonly) NSXPCConnection *connection;
+@property (weak) NSXPCConnection *relayConnection;
+
+@property (strong, nonatomic) NSMutableArray *connections;
 @property (nonatomic, assign) BOOL helperToolShouldQuit;
 @end
 
-@implementation LGAutoPkgrHelper
+@implementation LGAutoPkgrHelper {
+    void (^_resign)(BOOL);
+}
 
 - (id)init
 {
@@ -50,6 +54,7 @@ static const NSTimeInterval kHelperCheckInterval = 1.0; // how often to check wh
     if (self) {
         self->_listener = [[NSXPCListener alloc] initWithMachServiceName:kLGAutoPkgrHelperToolName];
         self->_listener.delegate = self;
+        self->_connections = [NSMutableArray new];
     }
     return self;
 }
@@ -76,12 +81,15 @@ static const NSTimeInterval kHelperCheckInterval = 1.0; // how often to check wh
         newConnection.exportedInterface = exportedInterface;
 
         newConnection.exportedObject = self;
-        self.connection = newConnection;
 
         __weak typeof(newConnection) weakConnection = newConnection;
         // If all connections are invalidated on the remote side, shutdown the helper.
         newConnection.invalidationHandler = ^() {
             __strong typeof(newConnection) strongConnection = weakConnection;
+            if ([strongConnection isEqualTo:self.relayConnection] && _resign) {
+                _resign(YES);
+            }
+
             [self.connections removeObject:strongConnection];
             if (!self.connections.count) {
                 [self quitHelper:^(BOOL success) {}];
@@ -96,6 +104,11 @@ static const NSTimeInterval kHelperCheckInterval = 1.0; // how often to check wh
 
     syslog(LOG_ERR, "Error creating xpc connection...");
     return NO;
+}
+
+- (NSXPCConnection *)connection
+{
+    return [self.connections lastObject];
 }
 
 #pragma mark - Password
@@ -367,6 +380,11 @@ helper_reply:
     for (NSXPCConnection *connection in self.connections) {
         [connection invalidate];
     }
+
+    if (_resign) {
+        _resign(YES);
+    }
+
     [self.connections removeAllObjects];
 
     self.helperToolShouldQuit = YES;
@@ -383,6 +401,37 @@ helper_reply:
     }
 
     reply(error);
+}
+
+#pragma mark - IPC communication from background run
+- (void)registerMainApplication:(void (^)(BOOL resign))resign;
+{
+    if(!self.relayConnection){
+        self.relayConnection = self.connection;
+        self.relayConnection.remoteObjectInterface = [NSXPCInterface interfaceWithProtocol:@protocol(LGProgressDelegate)];
+        _resign = resign;
+    } else {
+        resign(YES);
+    }
+}
+
+- (void)sendMessageToMainApplication:(NSString *)message progress:(double)progress error:(NSError *)error                             state:(LGBackgroundTaskProgressState)state;
+{
+    if (self.relayConnection) {
+        switch (state) {
+            case kLGAutoPkgProgressStart:
+                [self.relayConnection.remoteObjectProxy startProgressWithMessage:message];
+                break;
+            case kLGAutoPkgProgressProcessing:
+                [self.relayConnection.remoteObjectProxy updateProgress:message progress:progress];
+                break;
+            case kLGAutoPkgProgressComplete:
+                [self.relayConnection.remoteObjectProxy stopProgress:error];
+                break;
+            default:
+                break;
+        }
+    }
 }
 
 #pragma mark - Private

--- a/helper/LGAutoPkgrProtocol.h
+++ b/helper/LGAutoPkgrProtocol.h
@@ -21,6 +21,12 @@
 #import "LGConstants.h"
 #import "LGAutoPkgrAuthorizer.h"
 
+typedef NS_ENUM(NSInteger, LGBackgroundTaskProgressState) {
+    kLGAutoPkgProgressStart = -1,
+    kLGAutoPkgProgressProcessing = 0,
+    kLGAutoPkgProgressComplete = 1
+};
+
 @protocol HelperAgent <NSObject>
 
 # pragma mark - Password / KeyFile
@@ -47,5 +53,13 @@
 #pragma mark - Life Cycle
 - (void)quitHelper:(void (^)(BOOL success))reply;
 - (void)uninstall:(NSData *)authData reply:(void (^)(NSError *))reply;
+
+#pragma mark - IPC messaging
+- (void)registerMainApplication:(void (^)(BOOL resign))resign;
+
+- (void)sendMessageToMainApplication:(NSString *)message
+                            progress:(double)progress
+                               error:(NSError *)error
+                            state:(LGBackgroundTaskProgressState)state;
 
 @end

--- a/helper/helper-Info.plist
+++ b/helper/helper-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>com.lindegroup.AutoPkgr.helper</string>
 	<key>CFBundleVersion</key>
-	<string>1.2.4</string>
+	<string>1.2.5</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>identifier "com.lindegroup.AutoPkgr" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JVY2ZR6SEF</string>


### PR DESCRIPTION
So while trying to figure out the issues with makepkginfo error code 2, I was looking over the munki source code and came across this environmental key [__CFPREFERENCES_AVOID_DAEMON](https://github.com/munki/munki/blob/master/code/client/makepkginfo#L50)

While it looks like they use it there to prevent hanging, I had the inkling that it was exactly what we needed to circumvent the cfprefsd daemon during background runs. Sure enough it appears to work perfectly.

What happens now is this is added to the schedule launchd.plist
```
	<key>EnvironmentVariables</key>
	<dict>
		<key>__CFPREFERENCES_AVOID_DAEMON</key>
		<string>1</string>
	</dict>
```

With this change users __will__ need to disable and reenable the schedule, so we should put that at the top of the release info. But it is a much, much better fix.

It's wild how sometimes working on a different problem leads you back to the answer of the original.
