### PR TITLE
Minor adjustments to the keychain migration method.

### DIFF
--- a/AutoPkgr/LGConfigurationWindowController.m
+++ b/AutoPkgr/LGConfigurationWindowController.m
@@ -275,7 +275,7 @@
     if (account && password) {
         [LGPasswords savePassword:password forAccount:account reply:^(NSError *error) {
             if (error) {
-                if (error.code == errSecAuthFailed) {
+                if (error.code == errSecAuthFailed || error.code == errSecDuplicateKeychain) {
                     [LGPasswords resetKeychainPrompt:^(NSError *error) {
                         if (!error) {
                             [self updateKeychainPassword:nil];


### PR DESCRIPTION
James pointed out that we don't really need to do this if the AutoPkgr.keychain doesn't exist.
It also catches a one other error code which indicated the keychain needs a hard reset. 