### PR TITLE
V1.2.3 error handler

### DIFF
--- a/AutoPkgr.xcodeproj/project.pbxproj
+++ b/AutoPkgr.xcodeproj/project.pbxproj
@@ -92,6 +92,11 @@
 		BEE42DAD1AC6E2D100599238 /* report_malformed.plist in Resources */ = {isa = PBXBuildFile; fileRef = BEE42DAB1AC6E2D100599238 /* report_malformed.plist */; };
 		BEE42DAE1AC6E2D100599238 /* report_none.plist in Resources */ = {isa = PBXBuildFile; fileRef = BEE42DAC1AC6E2D100599238 /* report_none.plist */; };
 		BEE8CF1319E0E7F400981C4B /* NSTextField+setSafeStringValue.m in Sources */ = {isa = PBXBuildFile; fileRef = BEE8CF1219E0E7F400981C4B /* NSTextField+setSafeStringValue.m */; };
+		BEEFE6B71AE9D01200882C89 /* LGAutoPkgErrorHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BEEFE6B61AE9D01200882C89 /* LGAutoPkgErrorHandler.m */; };
+		BEEFE6B81AE9D01200882C89 /* LGAutoPkgErrorHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BEEFE6B61AE9D01200882C89 /* LGAutoPkgErrorHandler.m */; };
+		BEEFE6BB1AE9E8A600882C89 /* LGLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = BEEFE6B91AE9E8A600882C89 /* LGLogger.m */; };
+		BEEFE6BC1AE9E8A600882C89 /* LGLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = BEEFE6B91AE9E8A600882C89 /* LGLogger.m */; };
+		BEEFE6BD1AE9E9D500882C89 /* LGLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = BEEFE6B91AE9E8A600882C89 /* LGLogger.m */; };
 		BEFC3C761A3DF16700C789E9 /* LGUserNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = BE6815D41A0B18DE004AD310 /* LGUserNotifications.m */; };
 		BEFC3C771A3DF16700C789E9 /* LGGitHubJSONLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A1BAD9D197A4133008192A7 /* LGGitHubJSONLoader.m */; };
 		BEFC3C781A3DF16700C789E9 /* LGInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = BEAA76CB19BFD635002D73EE /* LGInstaller.m */; };
@@ -278,6 +283,10 @@
 		BEE42DAC1AC6E2D100599238 /* report_none.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = report_none.plist; sourceTree = "<group>"; };
 		BEE8CF1119E0E7F400981C4B /* NSTextField+setSafeStringValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSTextField+setSafeStringValue.h"; path = "Custom Categories/NSTextField+setSafeStringValue.h"; sourceTree = "<group>"; };
 		BEE8CF1219E0E7F400981C4B /* NSTextField+setSafeStringValue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSTextField+setSafeStringValue.m"; path = "Custom Categories/NSTextField+setSafeStringValue.m"; sourceTree = "<group>"; };
+		BEEFE6B51AE9D01200882C89 /* LGAutoPkgErrorHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGAutoPkgErrorHandler.h; sourceTree = "<group>"; };
+		BEEFE6B61AE9D01200882C89 /* LGAutoPkgErrorHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGAutoPkgErrorHandler.m; sourceTree = "<group>"; };
+		BEEFE6B91AE9E8A600882C89 /* LGLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGLogger.m; sourceTree = "<group>"; };
+		BEEFE6BA1AE9E8A600882C89 /* LGLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGLogger.h; sourceTree = "<group>"; };
 		BEFC931B1995F0710074C938 /* LGError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGError.h; sourceTree = "<group>"; };
 		BEFC931C1995F0710074C938 /* LGError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGError.m; sourceTree = "<group>"; };
 		FF435269A548437DA5380201 /* libPods-AutoPkgr.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AutoPkgr.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -331,7 +340,7 @@
 			isa = PBXGroup;
 			children = (
 				1AC69556195B59ED00D2BD81 /* AutoPkgr */,
-				BE05CE6819DAF26B0089068B /* helper */,
+				BE05CE6819DAF26B0089068B /* Privileged Helper */,
 				1AC6954F195B59ED00D2BD81 /* Frameworks */,
 				1AC6954E195B59ED00D2BD81 /* Products */,
 				1AC69574195B59EE00D2BD81 /* AutoPkgrTests */,
@@ -381,16 +390,13 @@
 		1AC69556195B59ED00D2BD81 /* AutoPkgr */ = {
 			isa = PBXGroup;
 			children = (
-				1AC86D36195E0972006FDD2B /* Feature Classes */,
+				BEEFE6BE1AEA82CD00882C89 /* AutoPkg Classes */,
+				1AC86D36195E0972006FDD2B /* Model Classes */,
 				BE40CB7719D4441600A1DABD /* UI Classes */,
 				BE40CB7819D4444D00A1DABD /* Utility Classes */,
 				BE05CE8419DAF63D0089068B /* Helper Tool Communication */,
 				BE39FE5419DFBB2900C1B4A1 /* Custom Categories */,
-				1AC69565195B59EE00D2BD81 /* MainMenu.xib */,
-				1AC9841E195CEC360071CAB3 /* LGConfigurationWindowController.xib */,
-				BE0BACD01A2560AE00554989 /* LGJSSDistributionPointsPrefPanel.xib */,
-				BE67E8741A44E10500484151 /* LGRecipeSearchPanel.xib */,
-				1AC69568195B59EE00D2BD81 /* Images.xcassets */,
+				BEEFE6BF1AEA873800882C89 /* XIBs */,
 				1AC98423195DF6270071CAB3 /* Resources */,
 				1AC69557195B59ED00D2BD81 /* Supporting Files */,
 			);
@@ -433,30 +439,35 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		1AC86D36195E0972006FDD2B /* Feature Classes */ = {
+		1AC86D36195E0972006FDD2B /* Model Classes */ = {
 			isa = PBXGroup;
 			children = (
+				BE344F531ABFBEAB00500AAE /* LGAutoPkgReport.h */,
+				BE344F541ABFBEAB00500AAE /* LGAutoPkgReport.m */,
 				BE025CFC19BAEF8800D36345 /* LGAutoPkgSchedule.h */,
 				BE025CFD19BAEF8800D36345 /* LGAutoPkgSchedule.m */,
-				BE025CF419BAE93400D36345 /* LGAutoPkgTask.h */,
-				BE025CF519BAE93400D36345 /* LGAutoPkgTask.m */,
 				1AC98410195CE8510071CAB3 /* LGEmailer.h */,
 				1AC98411195CE8520071CAB3 /* LGEmailer.m */,
-				BE6815D31A0B18DE004AD310 /* LGUserNotifications.h */,
-				BE6815D41A0B18DE004AD310 /* LGUserNotifications.m */,
 				1A1BAD9C197A4133008192A7 /* LGGitHubJSONLoader.h */,
 				1A1BAD9D197A4133008192A7 /* LGGitHubJSONLoader.m */,
 				BEAA76CA19BFD635002D73EE /* LGInstaller.h */,
 				BEAA76CB19BFD635002D73EE /* LGInstaller.m */,
 				6A53625B1988BE59008A949C /* LGTestPort.h */,
 				6A53625C1988BE59008A949C /* LGTestPort.m */,
+				BE8C7D6C1A86CEF600EBD32A /* LGTools.h */,
+				BE8C7D6D1A86CEF600EBD32A /* LGTools.m */,
+				BE6815D31A0B18DE004AD310 /* LGUserNotifications.h */,
+				BE6815D41A0B18DE004AD310 /* LGUserNotifications.m */,
+				BEBF7B151A4894AC00E9967F /* LGVersioner.h */,
+				BEBF7B161A4894AC00E9967F /* LGVersioner.m */,
 			);
-			name = "Feature Classes";
+			name = "Model Classes";
 			sourceTree = "<group>";
 		};
 		1AC98423195DF6270071CAB3 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				1AC69568195B59EE00D2BD81 /* Images.xcassets */,
 				1A2C7FAC19CC9F8300CFF472 /* scripts */,
 				8BB217F519709A2C00EF8B93 /* AutoPkgrIcon.png */,
 				1AC98425195DF6350071CAB3 /* autopkgr.png */,
@@ -479,7 +490,7 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		BE05CE6819DAF26B0089068B /* helper */ = {
+		BE05CE6819DAF26B0089068B /* Privileged Helper */ = {
 			isa = PBXGroup;
 			children = (
 				BE05CE6919DAF26B0089068B /* main.m */,
@@ -488,6 +499,7 @@
 				BE05CE7B19DAF5A30089068B /* LGAutoPkgrProtocol.h */,
 				BE05CE7D19DAF5B80089068B /* Supporting Files */,
 			);
+			name = "Privileged Helper";
 			path = helper;
 			sourceTree = "<group>";
 		};
@@ -573,18 +585,14 @@
 				BEFC931C1995F0710074C938 /* LGError.m */,
 				1AC86D3B195E0AC6006FDD2B /* LGHostInfo.h */,
 				1AC86D3C195E0AC6006FDD2B /* LGHostInfo.m */,
-				BE8C7D6C1A86CEF600EBD32A /* LGTools.h */,
-				BE8C7D6D1A86CEF600EBD32A /* LGTools.m */,
+				BEEFE6BA1AE9E8A600882C89 /* LGLogger.h */,
+				BEEFE6B91AE9E8A600882C89 /* LGLogger.m */,
 				BE0E857719D668F600B25B5E /* LGHTTPRequest.h */,
 				BE0E857819D668F600B25B5E /* LGHTTPRequest.m */,
 				BE053D131A8F90920021D97B /* LGPasswords.h */,
 				BE053D141A8F90920021D97B /* LGPasswords.m */,
 				1A1BAD94197A0407008192A7 /* LGVersionComparator.h */,
 				1A1BAD95197A0407008192A7 /* LGVersionComparator.m */,
-				BEBF7B151A4894AC00E9967F /* LGVersioner.h */,
-				BEBF7B161A4894AC00E9967F /* LGVersioner.m */,
-				BE344F531ABFBEAB00500AAE /* LGAutoPkgReport.h */,
-				BE344F541ABFBEAB00500AAE /* LGAutoPkgReport.m */,
 			);
 			name = "Utility Classes";
 			sourceTree = "<group>";
@@ -599,6 +607,28 @@
 				BED136B61AC3BE04003EBF0F /* NSArray+html_report.m */,
 			);
 			name = "Html Categories";
+			sourceTree = "<group>";
+		};
+		BEEFE6BE1AEA82CD00882C89 /* AutoPkg Classes */ = {
+			isa = PBXGroup;
+			children = (
+				BE025CF419BAE93400D36345 /* LGAutoPkgTask.h */,
+				BE025CF519BAE93400D36345 /* LGAutoPkgTask.m */,
+				BEEFE6B51AE9D01200882C89 /* LGAutoPkgErrorHandler.h */,
+				BEEFE6B61AE9D01200882C89 /* LGAutoPkgErrorHandler.m */,
+			);
+			name = "AutoPkg Classes";
+			sourceTree = "<group>";
+		};
+		BEEFE6BF1AEA873800882C89 /* XIBs */ = {
+			isa = PBXGroup;
+			children = (
+				1AC69565195B59EE00D2BD81 /* MainMenu.xib */,
+				1AC9841E195CEC360071CAB3 /* LGConfigurationWindowController.xib */,
+				BE0BACD01A2560AE00554989 /* LGJSSDistributionPointsPrefPanel.xib */,
+				BE67E8741A44E10500484151 /* LGRecipeSearchPanel.xib */,
+			);
+			name = XIBs;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -897,6 +927,7 @@
 				BE0BACD11A2560AE00554989 /* LGJSSDistributionPointsPrefPanel.m in Sources */,
 				BEC1258919F046FA006696C4 /* main.m in Sources */,
 				BED136B71AC3BE04003EBF0F /* NSArray+html_report.m in Sources */,
+				BEEFE6BB1AE9E8A600882C89 /* LGLogger.m in Sources */,
 				BED02ADC1A194F9C00714CC2 /* NSArray+filtered.m in Sources */,
 				1AC69564195B59EE00D2BD81 /* LGAppDelegate.m in Sources */,
 				BEC1258619F0465C006696C4 /* LGConfigurationWindowController.m in Sources */,
@@ -918,6 +949,7 @@
 				BE0E857919D668F600B25B5E /* LGHTTPRequest.m in Sources */,
 				BED136B11AC262CB003EBF0F /* NSString+html_report.m in Sources */,
 				1A1BAD9E197A4133008192A7 /* LGGitHubJSONLoader.m in Sources */,
+				BEEFE6B71AE9D01200882C89 /* LGAutoPkgErrorHandler.m in Sources */,
 				BEC1258C19F049A1006696C4 /* LGTableView.m in Sources */,
 				6A53625D1988BE59008A949C /* LGTestPort.m in Sources */,
 				BEFC931D1995F0710074C938 /* LGError.m in Sources */,
@@ -939,11 +971,13 @@
 				BEFC3C761A3DF16700C789E9 /* LGUserNotifications.m in Sources */,
 				BED136B81AC3BE04003EBF0F /* NSArray+html_report.m in Sources */,
 				BEFC3C771A3DF16700C789E9 /* LGGitHubJSONLoader.m in Sources */,
+				BEEFE6BC1AE9E8A600882C89 /* LGLogger.m in Sources */,
 				BED136AD1AC0F993003EBF0F /* LGPasswords.m in Sources */,
 				BED136AB1AC05B1D003EBF0F /* LGAutoPkgReport.m in Sources */,
 				BEFC3C781A3DF16700C789E9 /* LGInstaller.m in Sources */,
 				BEFC3C791A3DF16700C789E9 /* LGTestPort.m in Sources */,
 				BEFC3C7C1A3DF16700C789E9 /* LGPopularRepositories.m in Sources */,
+				BEEFE6B81AE9D01200882C89 /* LGAutoPkgErrorHandler.m in Sources */,
 				BEFC3C7D1A3DF16700C789E9 /* LGRecipes.m in Sources */,
 				BE67E8771A44F02B00484151 /* LGRecipeSearch.m in Sources */,
 				BED136AC1AC05B4C003EBF0F /* LGEmailer.m in Sources */,
@@ -976,6 +1010,7 @@
 			files = (
 				BE05CE9119DB380F0089068B /* LGConstants.m in Sources */,
 				BE1C810419E8224000EF77F3 /* NSImage+statusLight.m in Sources */,
+				BEEFE6BD1AE9E9D500882C89 /* LGLogger.m in Sources */,
 				BE05CE6A19DAF26B0089068B /* main.m in Sources */,
 				BE053D1B1A8F9DC00021D97B /* SNTCertificate.m in Sources */,
 				BE053D181A8F9DAA0021D97B /* SNTCodesignChecker.m in Sources */,

--- a/AutoPkgr/Custom Categories/NSString+cleaned.h
+++ b/AutoPkgr/Custom Categories/NSString+cleaned.h
@@ -35,4 +35,6 @@
 
 - (NSString *)truncateToLength:(NSInteger)length;
 
+- (NSString *)truncateToNumberOfLines:(NSInteger)count;
+
 @end

--- a/AutoPkgr/Custom Categories/NSString+cleaned.m
+++ b/AutoPkgr/Custom Categories/NSString+cleaned.m
@@ -47,4 +47,16 @@
     return self;
 }
 
+- (NSString *)truncateToNumberOfLines:(NSInteger)count
+{
+    if (self.length) {
+        NSArray *lines = [self componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+        // If the count is less, we don't need to do anything just send self back
+        if (lines.count > count) {
+            NSIndexSet *idxSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, count)];
+            return [[lines objectsAtIndexes:idxSet] componentsJoinedByString:@"\n"];
+        }
+    }
+    return self;
+}
 @end

--- a/AutoPkgr/LGAutoPkgErrorHandler.h
+++ b/AutoPkgr/LGAutoPkgErrorHandler.h
@@ -1,0 +1,51 @@
+//
+//  LGAutoPkgErrorHandler.h
+//
+//  Created by Eldon Ahrold on 4/23/15.
+//
+//  Copyright 2015 Eldon Ahrold
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+/* AutoPkg Task Verbs
+ */
+typedef NS_ENUM(NSInteger, LGAutoPkgVerb) {
+    kLGAutoPkgUndefinedVerb,
+    // recipe verbs
+    kLGAutoPkgRun,
+    kLGAutoPkgRecipeList,
+    kLGAutoPkgMakeOverride,
+    kLGAutoPkgSearch,
+
+    // repo verbs
+    kLGAutoPkgRepoAdd,
+    kLGAutoPkgRepoDelete,
+    kLGAutoPkgRepoUpdate,
+    kLGAutoPkgRepoList,
+
+    // other verbs
+    kLGAutoPkgVersion,
+};
+
+@interface LGAutoPkgErrorHandler : NSObject
+
+@property (nonatomic, readonly) NSPipe *pipe;
+@property (nonatomic, readonly) NSString *errorString;
+
+- (instancetype)initWithVerb:(LGAutoPkgVerb)verb;
+- (NSError *)errorWithExitCode:(NSInteger)exitCode;
+
+@end

--- a/AutoPkgr/LGAutoPkgErrorHandler.m
+++ b/AutoPkgr/LGAutoPkgErrorHandler.m
@@ -1,0 +1,219 @@
+//
+//  LGAutoPkgErrorHandler.m
+//
+//  Created by Eldon Ahrold on 4/23/15.
+//
+//  Copyright 2015 Eldon Ahrold
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "LGAutoPkgErrorHandler.h"
+#import "LGLogger.h"
+
+static NSString *errorMessageFromAutoPkgVerb(LGAutoPkgVerb verb)
+{
+    NSString *localizedBaseString;
+    NSString *message;
+
+    switch (verb) {
+    case kLGAutoPkgUndefinedVerb:
+        localizedBaseString = @"kLGAutoPkgUndefinedVerb";
+        break;
+    case kLGAutoPkgRun:
+        localizedBaseString = @"kLGAutoPkgRun";
+        break;
+    case kLGAutoPkgRecipeList:
+        localizedBaseString = @"kLGAutoPkgRecipeList";
+        break;
+    case kLGAutoPkgMakeOverride:
+        localizedBaseString = @"kLGAutoPkgMakeOverride";
+        break;
+    case kLGAutoPkgSearch:
+        localizedBaseString = @"kLGAutoPkgSearch";
+        break;
+    case kLGAutoPkgRepoAdd:
+        localizedBaseString = @"kLGAutoPkgRepoAdd";
+        break;
+    case kLGAutoPkgRepoDelete:
+        localizedBaseString = @"kLGAutoPkgRepoDelete";
+        break;
+    case kLGAutoPkgRepoUpdate:
+        localizedBaseString = @"kLGAutoPkgRepoUpdate";
+        break;
+    case kLGAutoPkgRepoList:
+        localizedBaseString = @"kLGAutoPkgRepoList";
+        break;
+    case kLGAutoPkgVersion:
+        localizedBaseString = @"kLGAutoPkgVersion";
+        break;
+    default:
+        localizedBaseString = @"kLGAutoPkgUndefinedVerb";
+        break;
+    }
+
+    message = NSLocalizedString([localizedBaseString stringByAppendingString:@"Description"],
+                                @"NSLocalizedDescriptionKey");
+    return message;
+}
+
+NSString *maskPasswordInString(NSString *string)
+{
+    NSError *error;
+    NSMutableString *retractedString = [string mutableCopy];
+
+    NSString *baseAll = @"a-zA-Z0-9~`!#.,$%^&*()-_{}<>?";
+    NSString *pattern = [NSString stringWithFormat:@"([%@]+:[%@]+(?=@))", baseAll, baseAll];
+
+    NSRegularExpression *exp = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
+
+    NSRange range = NSMakeRange(0, string.length);
+    NSArray *matches = [exp matchesInString:string options:0 range:range];
+    for (NSTextCheckingResult *match in matches) {
+        NSString *ms = [string substringWithRange:match.range];
+        NSArray *array = [ms componentsSeparatedByString:@":"];
+
+        // Make sure to re-range the retracted string each loop, since it gets modified.
+        NSRange r_range = NSMakeRange(0, retractedString.length);
+        [retractedString replaceOccurrencesOfString:[array lastObject]
+                                         withString:@"*******"
+                                            options:NSCaseInsensitiveSearch
+                                              range:r_range];
+    }
+
+    return [retractedString copy];
+}
+
+@implementation LGAutoPkgErrorHandler {
+    LGAutoPkgVerb _verb;
+    NSMutableOrderedSet *_errorStrings;
+    NSPipe *_pipe;
+}
+
+- (void)dealloc
+{
+    _pipe.fileHandleForReading.readabilityHandler = nil;
+    _pipe = nil;
+    DevLog(@"Dealloc Error Handler");
+}
+
+- (instancetype)initWithVerb:(LGAutoPkgVerb)verb
+{
+    if (self = [super init]) {
+        _verb = verb;
+
+        NSPipe *pipe = [NSPipe pipe];
+        _pipe = pipe;
+
+        [pipe.fileHandleForReading setReadabilityHandler:^(NSFileHandle *fh) {
+            NSData *data = fh.availableData;
+            if (data) {
+                NSString *str = [[NSMutableString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+
+                if (!_errorStrings) {
+                    _errorStrings = [[NSMutableOrderedSet alloc] init];
+                }
+                
+                [_errorStrings addObject:str];
+            }
+        }];
+    }
+    return self;
+}
+
+- (NSPipe *)standardError
+{
+    return _pipe;
+}
+
+- (NSString *)errorString
+{
+    NSArray *errors = nil;
+    NSString *errorString = nil;
+
+    if ((errors = _errorStrings.array)) {
+        NSArray *filters = @[ @"not (SELF BEGINSWITH[CD] 'Failed.')" ];
+
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:[filters componentsJoinedByString:@" AND "]];
+
+        errorString = [[_errorStrings.array filteredArrayUsingPredicate:predicate] componentsJoinedByString:@"\n"];
+    };
+    return errorString;
+}
+
+- (NSError *)errorWithExitCode:(NSInteger)exitCode
+{
+    NSError *error;
+    NSString *standardErrString = self.errorString;
+
+    if (!standardErrString.length || exitCode == NSTaskTerminationReasonUncaughtSignal) {
+        return nil;
+    }
+
+    NSString *errorMsg = errorMessageFromAutoPkgVerb(_verb);
+    NSString *errorDetails = maskPasswordInString(standardErrString);
+
+    // If the error message looks like a Python exception log it, but trim it up for UI.
+    NSPredicate *exceptionPredicate = [NSPredicate predicateWithFormat:@"SELF CONTAINS 'Traceback'"];
+    if ([exceptionPredicate evaluateWithObject:errorDetails]) {
+        NSArray *splitExceptionFromError = [errorDetails componentsSeparatedByString:@"Traceback (most recent call last):"];
+
+        // The exception should in theory always be last.
+        NSString *fullExceptionMessage = [splitExceptionFromError lastObject];
+        NSLog(@"(FULL AUTOPKG TRACEBACK) %@", fullExceptionMessage);
+
+        NSArray *array = [fullExceptionMessage componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+
+        NSPredicate *noEmptySpaces = [NSPredicate predicateWithFormat:@"not (SELF == '')"];
+        NSString *exceptionDetails = [[array filteredArrayUsingPredicate:noEmptySpaces] lastObject];
+
+        NSMutableString *recombinedErrorDetails = [[NSMutableString alloc] init];
+        if (splitExceptionFromError.count > 1) {
+            // If something came before, put that information back into the errorDetails.
+            [recombinedErrorDetails appendString:[splitExceptionFromError firstObject]];
+        }
+
+        [recombinedErrorDetails appendFormat:@"A Python exception occurred during the execution of autopkg, see the system log for more details.\n\n[ERROR] %@", exceptionDetails];
+
+        errorDetails = [NSString stringWithString:recombinedErrorDetails];
+
+        // Otherwise continue...
+    } else {
+        // AutoPkg's rc on a failed repo-update / add / delete is 0, but we want it reported back to the UI so set it to -1.
+        if (_verb == kLGAutoPkgRepoUpdate || _verb == kLGAutoPkgRepoDelete || _verb == kLGAutoPkgRepoAdd) {
+            if (errorDetails.length) {
+                exitCode = -1;
+            }
+        }
+        // autopkg run exits 255 if no recipe specified
+        else if (_verb == kLGAutoPkgRun && exitCode == 255) {
+            errorDetails = @"No recipes specified.";
+        }
+    }
+
+    // Otherwise we can just use the termination status
+    if (exitCode != 0) {
+        error = [NSError errorWithDomain:[[NSBundle mainBundle] bundleIdentifier]
+                                    code:exitCode
+                                userInfo:@{ NSLocalizedDescriptionKey : errorMsg,
+                                            NSLocalizedRecoverySuggestionErrorKey : errorDetails ?: @"" }];
+
+        // If Debugging is enabled, log the error message
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:@"debug"]) {
+            NSLog(@"Error [%ld] %@ \n %@", (long)exitCode, errorMsg, errorDetails);
+        }
+    }
+    return error;
+}
+
+@end

--- a/AutoPkgr/LGAutoPkgErrorHandler.m
+++ b/AutoPkgr/LGAutoPkgErrorHandler.m
@@ -153,66 +153,65 @@ NSString *maskPasswordInString(NSString *string)
 
 - (NSError *)errorWithExitCode:(NSInteger)exitCode
 {
-    NSError *error;
+    NSError *error = nil;
+    
     NSString *standardErrString = self.errorString;
+    if (standardErrString.length) {
+        NSString *errorMsg = errorMessageFromAutoPkgVerb(_verb);
+        NSString *errorDetails = maskPasswordInString(standardErrString);
 
-    if (!standardErrString.length || exitCode == NSTaskTerminationReasonUncaughtSignal) {
-        return nil;
-    }
+        // If the error message looks like a Python exception log it, but trim it up for UI.
+        NSPredicate *exceptionPredicate = [NSPredicate predicateWithFormat:@"SELF CONTAINS 'Traceback'"];
+        if ([exceptionPredicate evaluateWithObject:errorDetails]) {
+            NSArray *splitExceptionFromError = [errorDetails componentsSeparatedByString:@"Traceback (most recent call last):"];
 
-    NSString *errorMsg = errorMessageFromAutoPkgVerb(_verb);
-    NSString *errorDetails = maskPasswordInString(standardErrString);
+            // The exception should in theory always be last.
+            NSString *fullExceptionMessage = [splitExceptionFromError lastObject];
+            NSLog(@"(FULL AUTOPKG TRACEBACK) %@", fullExceptionMessage);
 
-    // If the error message looks like a Python exception log it, but trim it up for UI.
-    NSPredicate *exceptionPredicate = [NSPredicate predicateWithFormat:@"SELF CONTAINS 'Traceback'"];
-    if ([exceptionPredicate evaluateWithObject:errorDetails]) {
-        NSArray *splitExceptionFromError = [errorDetails componentsSeparatedByString:@"Traceback (most recent call last):"];
+            NSArray *array = [fullExceptionMessage componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
 
-        // The exception should in theory always be last.
-        NSString *fullExceptionMessage = [splitExceptionFromError lastObject];
-        NSLog(@"(FULL AUTOPKG TRACEBACK) %@", fullExceptionMessage);
+            NSPredicate *noEmptySpaces = [NSPredicate predicateWithFormat:@"not (SELF == '')"];
+            NSString *exceptionDetails = [[array filteredArrayUsingPredicate:noEmptySpaces] lastObject];
 
-        NSArray *array = [fullExceptionMessage componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+            NSMutableString *recombinedErrorDetails = [[NSMutableString alloc] init];
+            if (splitExceptionFromError.count > 1) {
+                // If something came before, put that information back into the errorDetails.
+                [recombinedErrorDetails appendString:[splitExceptionFromError firstObject]];
+            }
 
-        NSPredicate *noEmptySpaces = [NSPredicate predicateWithFormat:@"not (SELF == '')"];
-        NSString *exceptionDetails = [[array filteredArrayUsingPredicate:noEmptySpaces] lastObject];
+            [recombinedErrorDetails appendFormat:@"A Python exception occurred during the execution of autopkg, see the system log for more details.\n\n[ERROR] %@", exceptionDetails];
 
-        NSMutableString *recombinedErrorDetails = [[NSMutableString alloc] init];
-        if (splitExceptionFromError.count > 1) {
-            // If something came before, put that information back into the errorDetails.
-            [recombinedErrorDetails appendString:[splitExceptionFromError firstObject]];
-        }
+            errorDetails = [NSString stringWithString:recombinedErrorDetails];
 
-        [recombinedErrorDetails appendFormat:@"A Python exception occurred during the execution of autopkg, see the system log for more details.\n\n[ERROR] %@", exceptionDetails];
-
-        errorDetails = [NSString stringWithString:recombinedErrorDetails];
-
-        // Otherwise continue...
-    } else {
-        // AutoPkg's rc on a failed repo-update / add / delete is 0, but we want it reported back to the UI so set it to -1.
-        if (_verb == kLGAutoPkgRepoUpdate || _verb == kLGAutoPkgRepoDelete || _verb == kLGAutoPkgRepoAdd) {
-            if (errorDetails.length) {
-                exitCode = -1;
+            // Otherwise continue...
+        } else {
+            // AutoPkg's rc on a failed repo-update / add / delete is 0, but we want it reported back to the UI so set it to -1.
+            if (_verb == kLGAutoPkgRepoUpdate || _verb == kLGAutoPkgRepoDelete || _verb == kLGAutoPkgRepoAdd) {
+                if (errorDetails.length) {
+                    exitCode = -1;
+                }
+            }
+            // autopkg run exits 255 if no recipe specified
+            else if (_verb == kLGAutoPkgRun && exitCode == 255) {
+                errorDetails = @"No recipes specified.";
             }
         }
-        // autopkg run exits 255 if no recipe specified
-        else if (_verb == kLGAutoPkgRun && exitCode == 255) {
-            errorDetails = @"No recipes specified.";
+
+        // Otherwise we can just use the termination status
+        if (exitCode != 0) {
+            error = [NSError errorWithDomain:[[NSBundle mainBundle] bundleIdentifier]
+                                        code:exitCode
+                                    userInfo:@{ NSLocalizedDescriptionKey : errorMsg,
+                                                NSLocalizedRecoverySuggestionErrorKey : errorDetails ?: @"" }];
+            
+            // If Debugging is enabled, log the error message
+            if ([[NSUserDefaults standardUserDefaults] boolForKey:@"debug"]) {
+                NSLog(@"Error [%ld] %@ \n %@", (long)exitCode, errorMsg, errorDetails);
+            }
         }
     }
 
-    // Otherwise we can just use the termination status
-    if (exitCode != 0) {
-        error = [NSError errorWithDomain:[[NSBundle mainBundle] bundleIdentifier]
-                                    code:exitCode
-                                userInfo:@{ NSLocalizedDescriptionKey : errorMsg,
-                                            NSLocalizedRecoverySuggestionErrorKey : errorDetails ?: @"" }];
-
-        // If Debugging is enabled, log the error message
-        if ([[NSUserDefaults standardUserDefaults] boolForKey:@"debug"]) {
-            NSLog(@"Error [%ld] %@ \n %@", (long)exitCode, errorMsg, errorDetails);
-        }
-    }
     return error;
 }
 

--- a/AutoPkgr/LGAutoPkgTask.h
+++ b/AutoPkgr/LGAutoPkgTask.h
@@ -20,12 +20,14 @@
 //
 
 #import <Foundation/Foundation.h>
+
 #import "LGAutoPkgr.h"
 #import "LGProgressDelegate.h"
 
 @class LGAutoPkgTaskManager;
 @class LGAutoPkgTask;
 @class LGAutoPkgTaskResponseObject;
+
 /**
  *  Constant to access recipe key in autopkg search or recipe-list
  */
@@ -154,6 +156,11 @@ extern NSString *const kLGAutoPkgRepoURLKey;
  *  stderr from autopkg
  */
 @property (copy, nonatomic, readonly) NSString *standardErrString;
+
+/**
+ *  Exit code from autopkg
+ */
+@property (nonatomic, assign) int exitCode;
 
 /**
  * An array of dictionaries based on the autopkg verb

--- a/AutoPkgr/LGAutoPkgTask.m
+++ b/AutoPkgr/LGAutoPkgTask.m
@@ -167,6 +167,7 @@ typedef void (^AutoPkgReplyErrorBlock)(NSError *error);
 @implementation LGAutoPkgTask {
     BOOL _isExecuting;
     BOOL _isFinished;
+    BOOL _userCanceled;
 }
 
 - (NSString *)taskDescription
@@ -224,6 +225,8 @@ typedef void (^AutoPkgReplyErrorBlock)(NSError *error);
 - (void)cancel
 {
     [self.taskLock lock];
+
+    _userCanceled = YES;
     if (self.task && self.task.isRunning) {
         DLog(@"Canceling %@", self.taskDescription);
         [self.task terminate];
@@ -319,7 +322,7 @@ typedef void (^AutoPkgReplyErrorBlock)(NSError *error);
         [self.task.standardError fileHandleForReading].readabilityHandler = nil;
     }
 
-    if (!_error) {
+    if (!_error && !_userCanceled) {
         [self.taskLock lock];
         self.error = [_errorHandler errorWithExitCode:self.task.terminationStatus];
         [self.taskLock unlock];

--- a/AutoPkgr/LGAutoPkgr.h
+++ b/AutoPkgr/LGAutoPkgr.h
@@ -24,6 +24,7 @@
 
 #import "LGConstants.h"
 #import "LGError.h"
+#import "LGLogger.h"
 #import "LGHostInfo.h"
 #import "LGDefaults+JSSImporter.h"
 #import "NSString+cleaned.h"

--- a/AutoPkgr/LGConfigurationWindowController.m
+++ b/AutoPkgr/LGConfigurationWindowController.m
@@ -850,8 +850,14 @@
 
         if (error) {
             SEL selector = nil;
-            NSAlert *alert = [NSAlert alertWithError:error];
-            [alert addButtonWithTitle:@"OK"];
+            NSString *truncatedString = [error.localizedRecoverySuggestion truncateToNumberOfLines:25];
+            if (![truncatedString isEqualToString:error.localizedRecoverySuggestion]) {
+                truncatedString = [NSString stringWithFormat:@"%@\nMore details have been logged to the system.log", truncatedString];
+                NSLog(@"%@", error.localizedRecoverySuggestion);
+            }
+
+            NSAlert *alert = [NSAlert alertWithMessageText:error.localizedDescription defaultButton:@"OK" alternateButton:nil otherButton:nil informativeTextWithFormat:@"%@", truncatedString ];
+
             // If AutoPkg exits -1 it may be misconfigured
             if (error.code == kLGErrorAutoPkgConfig) {
                 [alert addButtonWithTitle:@"Try to repair settings"];

--- a/AutoPkgr/LGError.h
+++ b/AutoPkgr/LGError.h
@@ -21,7 +21,6 @@
 
 #import <Foundation/Foundation.h>
 
-void DLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
 
 #pragma mark - AutoPkgr specific Error codes
 typedef NS_ENUM(NSInteger, LGErrorCodes) {
@@ -64,24 +63,6 @@ typedef NS_ENUM(NSInteger, LGErrorAutoPkgCodes) {
     kLGErrorAutoPkgNoRecipes = 255,
 };
 
-typedef NS_ENUM(NSInteger, LGAutoPkgVerb) {
-    kLGAutoPkgUndefinedVerb,
-    // recipe verbs
-    kLGAutoPkgRun,
-    kLGAutoPkgRecipeList,
-    kLGAutoPkgMakeOverride,
-    kLGAutoPkgSearch,
-
-    // repo verbs
-    kLGAutoPkgRepoAdd,
-    kLGAutoPkgRepoDelete,
-    kLGAutoPkgRepoUpdate,
-    kLGAutoPkgRepoList,
-
-    // other verbs
-    kLGAutoPkgVersion,
-};
-
 @interface LGError : NSObject
 
 #ifdef _APPKITDEFINES_H
@@ -112,28 +93,8 @@ typedef NS_ENUM(NSInteger, LGAutoPkgVerb) {
  */
 + (NSError *)errorWithCode:(LGErrorCodes)code;
 
-#pragma mark - NSTask Error
-/**
- *  Populate an NSError using a completed NSTask
- *
- *  @param task  Completed NSTask Object
- *  @param verb  Cooresponding Action Word Describing the AutoPkgr task process
- *  @param error __autoreleasing NSError object
- *
- *  @return NO if error occurred and the exit code is not 0, otherwise YES;
- *  @discussion If the task is not complete this will return YES;
- */
-+ (BOOL)errorWithTaskError:(NSTask *)task verb:(LGAutoPkgVerb)verb error:(NSError **)error;
-/**
- *  Generated NSError Object from and AutoPkgr NSTask
- *
- *  @param task  Completed NSTask Object
- *  @param verb  Cooresponding Action Word Describing the AutoPkgr task process
- *
- *  @return Populated NSError Object if exit status is != kLGErrorSuccess, nil otherwise;
- *  @discussion If the returned object will be nil if the task has not complete;
- */
-+ (NSError *)errorWithTaskError:(NSTask *)task verb:(LGAutoPkgVerb)verb;
++ (NSError *)errorFromTask:(NSTask *)task;
+
 
 #pragma mark - NSURLConnection response Error
 + (BOOL)errorWithResponse:(NSHTTPURLResponse *)response error:(NSError **)error;

--- a/AutoPkgr/LGLogger.h
+++ b/AutoPkgr/LGLogger.h
@@ -1,0 +1,12 @@
+//
+//  LGLogger.h
+//  AutoPkgr
+//
+//  Created by Eldon on 4/23/15.
+//  Copyright (c) 2015 The Linde Group, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+void DLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+void DevLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);

--- a/AutoPkgr/LGLogger.m
+++ b/AutoPkgr/LGLogger.m
@@ -27,7 +27,7 @@ void DevLog(NSString *format, ...)
     if (format) {
         va_list args;
         va_start(args, format);
-        NSLogv([@"[DEVELOPER] " stringByAppendingString:format], args);
+        NSLogv([@"[DEVEL] " stringByAppendingString:format], args);
         va_end(args);
     }
 #endif

--- a/AutoPkgr/LGLogger.m
+++ b/AutoPkgr/LGLogger.m
@@ -1,0 +1,34 @@
+//
+//  LGLogger.c
+//  AutoPkgr
+//
+//  Created by Eldon on 4/23/15.
+//  Copyright (c) 2015 The Linde Group, Inc. All rights reserved.
+//
+
+#include "LGLogger.h"
+
+// Debug Logging Method
+void DLog(NSString *format, ...)
+{
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"debug"]) {
+        if (format) {
+            va_list args;
+            va_start(args, format);
+            NSLogv([@"[DEBUG] " stringByAppendingString:format], args);
+            va_end(args);
+        }
+    }
+}
+
+void DevLog(NSString *format, ...)
+{
+#if DEBUG
+    if (format) {
+        va_list args;
+        va_start(args, format);
+        NSLogv([@"[DEVELOPER] " stringByAppendingString:format], args);
+        va_end(args);
+    }
+#endif
+}

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ AutoPkgr = ["AutoPkgr", "AutoPkgrTests"]
 
 AutoPkgr.each { |t|
     target t do
-        pod 'AFNetworking', '~> 2.4.1'
+        pod 'AFNetworking', '~> 2.5.3'
         pod 'Sparkle', '1.8'
         pod 'XMLDictionary', '~> 1.4'
         pod 'mailcore2-osx', '~> 0.5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
-  - AFNetworking (2.5.2):
-    - AFNetworking/NSURLConnection (= 2.5.2)
-    - AFNetworking/NSURLSession (= 2.5.2)
-    - AFNetworking/Reachability (= 2.5.2)
-    - AFNetworking/Security (= 2.5.2)
-    - AFNetworking/Serialization (= 2.5.2)
-    - AFNetworking/UIKit (= 2.5.2)
-  - AFNetworking/NSURLConnection (2.5.2):
+  - AFNetworking (2.5.3):
+    - AFNetworking/NSURLConnection (= 2.5.3)
+    - AFNetworking/NSURLSession (= 2.5.3)
+    - AFNetworking/Reachability (= 2.5.3)
+    - AFNetworking/Security (= 2.5.3)
+    - AFNetworking/Serialization (= 2.5.3)
+    - AFNetworking/UIKit (= 2.5.3)
+  - AFNetworking/NSURLConnection (2.5.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.2):
+  - AFNetworking/NSURLSession (2.5.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.2)
-  - AFNetworking/Security (2.5.2)
-  - AFNetworking/Serialization (2.5.2)
+  - AFNetworking/Reachability (2.5.3)
+  - AFNetworking/Security (2.5.3)
+  - AFNetworking/Serialization (2.5.3)
   - AHKeychain (0.2.1)
   - AHLaunchCtl (0.4.2)
   - AHProxySettings (0.1.1)
@@ -26,7 +26,7 @@ PODS:
   - XMLDictionary (1.4)
 
 DEPENDENCIES:
-  - AFNetworking (from `https://github.com/AFNetworking/AFNetworking.git`)
+  - AFNetworking (~> 2.5.3)
   - AHKeychain (~> 0.2.1)
   - AHLaunchCtl (~> 0.4.1)
   - AHProxySettings (~> 0.1.1)
@@ -35,17 +35,8 @@ DEPENDENCIES:
   - Sparkle (= 1.8)
   - XMLDictionary (~> 1.4)
 
-EXTERNAL SOURCES:
-  AFNetworking:
-    :git: https://github.com/AFNetworking/AFNetworking.git
-
-CHECKOUT OPTIONS:
-  AFNetworking:
-    :commit: 0c9216e86ec0822e7556ceaecedfe3bc2a4b486d
-    :git: https://github.com/AFNetworking/AFNetworking.git
-
 SPEC CHECKSUMS:
-  AFNetworking: f0e3cd9309e4ea3710d557938a2710f0f1111ca2
+  AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
   AHKeychain: f797278e48ab3ddb4d62370b84583652bc071baa
   AHLaunchCtl: 8f8bb26326627756aa4e85609a2e1896b8dfe874
   AHProxySettings: 1f882780699d7765aca9377660ba280306d30910

--- a/helper/LGAutoPkgrHelper.m
+++ b/helper/LGAutoPkgrHelper.m
@@ -365,7 +365,7 @@ helper_reply:
     }];
 
     [task setTerminationHandler:^(NSTask *endTask) {
-        NSError *error = [LGError errorWithTaskError:endTask verb:kLGAutoPkgUndefinedVerb];
+        NSError *error = [LGError errorFromTask:endTask];
         reply(error);
     }];
 


### PR DESCRIPTION
Fixes condition where the NSPipe from autopkg `stderr` would reach a max size causing AutoPkg to hang [ issue #334 ]

Added AutoPkgErrorHandler class.
Re-arranged some of the workspace's folder structure.
Updated Podfile
