### PR TITLE
Handle JSS response as XML or JSON

### DIFF
--- a/AutoPkgr/LGJSSImporter.m
+++ b/AutoPkgr/LGJSSImporter.m
@@ -130,13 +130,10 @@ NSPredicate *jdsFilterPredicate()
 
                                       [[NSOperationQueue mainQueue] addOperationWithBlock:^{
                                           [self stopStatusUpdate:error];
-                                           id distPoints = distributionPoints[@"distribution_point"];
-                                           if (distPoints) {
-                                               NSArray *cleanedArray = [self evaluateJSSRepoDictionaries:distPoints];
-                                               if (cleanedArray) {
-                                                   _defaults.JSSRepos = cleanedArray;
-                                                   [_jssDistributionPointTableView reloadData];
-                                               }
+                                            NSArray *cleanedArray = [self evaluateJSSRepoDictionaries:distributionPoints];
+                                           if (cleanedArray) {
+                                               _defaults.JSSRepos = cleanedArray;
+                                               [_jssDistributionPointTableView reloadData];
                                            }
                                       }];
                                   }];
@@ -300,8 +297,18 @@ NSPredicate *jdsFilterPredicate()
     }];
 }
 
-- (NSArray *)evaluateJSSRepoDictionaries:(id)distPoints
+- (NSArray *)evaluateJSSRepoDictionaries:(NSDictionary *)distributionPoints
 {
+
+    id distPoints;
+
+    // If the object was parsed as an XML object the key we're looking for is
+    // distribution_point. If the object is a JSON object the key is distribution_points
+    if ((distPoints = distributionPoints[@"distribution_point"]) == nil &&
+        (distPoints = distributionPoints[@"distribution_points"]) == nil) {
+        return nil;
+    }
+
     NSArray *dictArray;
     NSMutableArray *newRepos;
 
@@ -318,8 +325,10 @@ NSPredicate *jdsFilterPredicate()
     // If the "type" key is not set for the DP then it's auto detected via the server
     // and we'll strip them out here.
     LGDefaults *defaults = [LGDefaults standardUserDefaults];
+    
     NSPredicate *customDistPointsPredicate = [NSPredicate predicateWithFormat:@"not %K == nil", kLGJSSDistPointTypeKey];
     NSArray *customDistPoints = [defaults.JSSRepos filteredArrayUsingPredicate:customDistPointsPredicate];
+
     newRepos = [[NSMutableArray alloc] initWithArray:customDistPoints];
 
     if (dictArray) {


### PR DESCRIPTION
@homebysix, 
Not sure if you want to squeeze this in, but this should address some inconsistencies between JSS servers. Some are sending back JSON rather than XML. This PR will tell the server to send xml in the request header, but will also handle JSON responses if the server doesn't comply.

[Reverence to the issue on jamf nation](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&ved=0CB8QFjAA&url=https%3A%2F%2Fjamfnation.jamfsoftware.com%2Fdiscussion.html%3Fid%3D7673&ei=5r9MVdEKweiwBfK1gOgO&usg=AFQjCNH9JJYn_F3IdIRbyFWq1610rw_b1Q&sig2=W6PQYneU363cRZ-o86jwZg&bvm=bv.92765956,d.b2w)

If you don't want to get this into 1.2.3, no big deal. 
I've got my sights set on doing a rework of the JSSImporter class the next go around and can fix it then.
