### PR TITLE
Handle `autopkg search` string parsing better. Split on "  " and trim.

### DIFF
--- a/AutoPkgr/Models/AutoPkg Task/LGAutoPkgResultHandler.m
+++ b/AutoPkgr/Models/AutoPkg Task/LGAutoPkgResultHandler.m
@@ -114,10 +114,7 @@
 
             __block NSMutableArray *searchResults;
 
-            NSMutableCharacterSet *repoCharacters = [NSMutableCharacterSet alphanumericCharacterSet];
-            [repoCharacters formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
-
-            NSCharacterSet *skippedCharacters = [NSCharacterSet whitespaceCharacterSet];
+            NSMutableCharacterSet *whiteSpace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
 
             NSPredicate *skipLinePredicate = [NSPredicate predicateWithFormat:@"SELF BEGINSWITH 'To add' \
                                                                                 or SELF BEGINSWITH '----' \
@@ -125,17 +122,12 @@
 
             [self.dataString enumerateLinesUsingBlock:^(NSString *line, BOOL *stop) {
                     if (![skipLinePredicate evaluateWithObject:line ]) {
-                        NSScanner *scanner = [NSScanner scannerWithString:line];
-                        [scanner setCharactersToBeSkipped:skippedCharacters];
+                        NSArray *array = [line componentsSeparatedByString:@"  "].filtered_noEmptyStrings;
+                        if (array.count == 3) {
+                            NSString *recipe = [array[0] stringByTrimmingCharactersInSet:whiteSpace];
+                            NSString *repo = [array[1] stringByTrimmingCharactersInSet:whiteSpace];
+                            NSString *path = [array[2] stringByTrimmingCharactersInSet:whiteSpace];
 
-                        NSString *recipe, *repo, *path;
-
-                        [scanner scanCharactersFromSet:repoCharacters intoString:&recipe];
-                        [scanner scanCharactersFromSet:repoCharacters intoString:&repo];
-                        [scanner scanCharactersFromSet:repoCharacters intoString:&path];
-
-
-                        if (recipe && repo && path) {
                             if (!searchResults) {
                                 searchResults = [[NSMutableArray alloc] init];
                             }

--- a/AutoPkgr/Models/AutoPkg Task/LGAutoPkgResultHandler.m
+++ b/AutoPkgr/Models/AutoPkg Task/LGAutoPkgResultHandler.m
@@ -114,7 +114,7 @@
 
             __block NSMutableArray *searchResults;
 
-            NSMutableCharacterSet *whiteSpace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+            NSCharacterSet *whiteSpace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
 
             NSPredicate *skipLinePredicate = [NSPredicate predicateWithFormat:@"SELF BEGINSWITH 'To add' \
                                                                                 or SELF BEGINSWITH '----' \

--- a/AutoPkgr/Views-Controllers-XIB/Integration Views/LGAutoPkgIntegrationView.xib
+++ b/AutoPkgr/Views-Controllers-XIB/Integration Views/LGAutoPkgIntegrationView.xib
@@ -226,6 +226,13 @@
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
+                                <connections>
+                                    <binding destination="oEY-e7-qCZ" name="value" keyPath="values.GitHubAPITokenAccount" id="vQ3-04-49n">
+                                        <dictionary key="options">
+                                            <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                                        </dictionary>
+                                    </binding>
+                                </connections>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GwV-tn-iky">
                                 <rect key="frame" x="316" y="28" width="152" height="32"/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. This projec
 - Fixed a bug where schedule changes would not reload in-memory launchd schedule.
 - Fixed a bug that would prevent JSS_REPOS defaults from getting set.
 - Fixed a bug that would result in repos appearing twice in the repo table. (#406)
+- Fixed a bug causing search results to be incorrectly formatted.
 
 ## [1.3] - 2015-05-08
 


### PR DESCRIPTION
Here's a bandaid for #410. Strings are now split correctly. 