### PR TITLE
FileWaveImporter integration

### DIFF
--- a/AutoPkgr.xcodeproj/project.pbxproj
+++ b/AutoPkgr.xcodeproj/project.pbxproj
@@ -27,9 +27,9 @@
 		1AC98427195DF6350071CAB3 /* autopkgr.png in Resources */ = {isa = PBXBuildFile; fileRef = 1AC98425195DF6350071CAB3 /* autopkgr.png */; };
 		1AC98429195DF6DE0071CAB3 /* autopkgr_alt.png in Resources */ = {isa = PBXBuildFile; fileRef = 1AC98428195DF6DE0071CAB3 /* autopkgr_alt.png */; };
 		6A53625D1988BE59008A949C /* LGTestPort.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A53625C1988BE59008A949C /* LGTestPort.m */; };
-		8B1AF8521BED81440013BE37 /* LGFileWaveIntegrationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1AF8501BED81440013BE37 /* LGFileWaveIntegrationView.m */; settings = {ASSET_TAGS = (); }; };
-		8B1AF8531BED81440013BE37 /* LGFileWaveIntegrationView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8B1AF8511BED81440013BE37 /* LGFileWaveIntegrationView.xib */; settings = {ASSET_TAGS = (); }; };
-		8B1AF8561BED81540013BE37 /* LGFileWaveIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1AF8551BED81540013BE37 /* LGFileWaveIntegration.m */; settings = {ASSET_TAGS = (); }; };
+		8B1AF8521BED81440013BE37 /* LGFileWaveIntegrationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1AF8501BED81440013BE37 /* LGFileWaveIntegrationView.m */; };
+		8B1AF8531BED81440013BE37 /* LGFileWaveIntegrationView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8B1AF8511BED81440013BE37 /* LGFileWaveIntegrationView.xib */; };
+		8B1AF8561BED81540013BE37 /* LGFileWaveIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1AF8551BED81540013BE37 /* LGFileWaveIntegration.m */; };
 		8BB217F619709A2C00EF8B93 /* AutoPkgrIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 8BB217F519709A2C00EF8B93 /* AutoPkgrIcon.png */; };
 		9D2C8D4C186E66B3303DD645 /* libPods-com.lindegroup.AutoPkgr.helper.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00A11C97CD6260BB5679DA1A /* libPods-com.lindegroup.AutoPkgr.helper.a */; };
 		B8D45ABF903D8E3083FBEFAC /* libPods-AutoPkgrTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EF915ABFCFD78F7257B58CD /* libPods-AutoPkgrTests.a */; };
@@ -169,6 +169,8 @@
 		BE91A06D1B2F298900ED7501 /* AHHelpPopover.m in Sources */ = {isa = PBXBuildFile; fileRef = BE91A06B1B2F298900ED7501 /* AHHelpPopover.m */; };
 		BE91A0701B2F53F000ED7501 /* NSString+attributedString.m in Sources */ = {isa = PBXBuildFile; fileRef = BE91A06F1B2F53F000ED7501 /* NSString+attributedString.m */; };
 		BE91A0711B2F53F000ED7501 /* NSString+attributedString.m in Sources */ = {isa = PBXBuildFile; fileRef = BE91A06F1B2F53F000ED7501 /* NSString+attributedString.m */; };
+		BEB27FCC1BED8FF20084DA0F /* LGFileWaveIntegrationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1AF8501BED81440013BE37 /* LGFileWaveIntegrationView.m */; };
+		BEB27FCD1BED8FF80084DA0F /* LGFileWaveIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1AF8551BED81540013BE37 /* LGFileWaveIntegration.m */; };
 		BEB9AF271B419F0900016D98 /* LGNotificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BE0BB0F11B3C2311007F9DA5 /* LGNotificationManager.m */; };
 		BEB9AF2B1B41A01900016D98 /* LGSlackNotificationView.m in Sources */ = {isa = PBXBuildFile; fileRef = BEB9AF291B41A01900016D98 /* LGSlackNotificationView.m */; };
 		BEB9AF2C1B41A01900016D98 /* LGSlackNotificationView.m in Sources */ = {isa = PBXBuildFile; fileRef = BEB9AF291B41A01900016D98 /* LGSlackNotificationView.m */; };
@@ -1015,9 +1017,6 @@
 		BE5E559C1B1A5B6E0025CFD3 /* Integration Views */ = {
 			isa = PBXGroup;
 			children = (
-				8B1AF84F1BED81440013BE37 /* LGFileWaveIntegrationView.h */,
-				8B1AF8501BED81440013BE37 /* LGFileWaveIntegrationView.m */,
-				8B1AF8511BED81440013BE37 /* LGFileWaveIntegrationView.xib */,
 				BECDAB861B234EE700544388 /* Window Controller (Integration) */,
 				BECDAB871B234F0200544388 /* Base View Controller (Integration) */,
 				BECDABA41B254E5900544388 /* LGAbsoluteManageIntegrationView.h */,
@@ -1026,15 +1025,18 @@
 				BE09F6581B2694ED00EE4AA7 /* LGAutoPkgIntegrationView.h */,
 				BE09F6591B2694ED00EE4AA7 /* LGAutoPkgIntegrationView.m */,
 				BE09F65A1B2694ED00EE4AA7 /* LGAutoPkgIntegrationView.xib */,
-				BE2337CC1B3E482100256F85 /* LGMacPatchIntegrationView.h */,
-				BE2337CD1B3E482100256F85 /* LGMacPatchIntegrationView.m */,
-				BE2337CE1B3E482100256F85 /* LGMacPatchIntegrationView.xib */,
+				8B1AF84F1BED81440013BE37 /* LGFileWaveIntegrationView.h */,
+				8B1AF8501BED81440013BE37 /* LGFileWaveIntegrationView.m */,
+				8B1AF8511BED81440013BE37 /* LGFileWaveIntegrationView.xib */,
 				BE32B0351B2735DF0071778B /* LGGitIntegrationView.h */,
 				BE32B0361B2735DF0071778B /* LGGitIntegrationView.m */,
 				BE32B0371B2735DF0071778B /* LGGitIntegrationView.xib */,
 				BE81F2271B2232ED007D16C4 /* LGJSSImporterIntegrationView.h */,
 				BE81F2281B2232ED007D16C4 /* LGJSSImporterIntegrationView.m */,
 				BE81F2391B22A29E007D16C4 /* LGJSSImporterIntegrationView.xib */,
+				BE2337CC1B3E482100256F85 /* LGMacPatchIntegrationView.h */,
+				BE2337CD1B3E482100256F85 /* LGMacPatchIntegrationView.m */,
+				BE2337CE1B3E482100256F85 /* LGMacPatchIntegrationView.xib */,
 				BECDAB921B24C29600544388 /* LGMunkiIntegrationView.h */,
 				BECDAB931B24C29600544388 /* LGMunkiIntegrationView.m */,
 				BECDAB941B24C29600544388 /* LGMunkiIntegrationView.xib */,
@@ -1147,14 +1149,14 @@
 		BEEFE6C41AEBEA6A00882C89 /* Integrations */ = {
 			isa = PBXGroup;
 			children = (
-				8B1AF8541BED81540013BE37 /* LGFileWaveIntegration.h */,
-				8B1AF8551BED81540013BE37 /* LGFileWaveIntegration.m */,
 				BE4DD5441B1239A300854FD8 /* Integration Manager */,
 				BEEFE6D21AF008A200882C89 /* LGIntegration Base */,
 				BE81F2211B20EFDD007D16C4 /* LGAbsoluteManageIntegration.h */,
 				BE81F2221B20EFF2007D16C4 /* LGAbsoluteManageIntegration.m */,
 				BEEFE6C81AEC760700882C89 /* LGAutoPkgIntegration.h */,
 				BEEFE6C91AEC760700882C89 /* LGAutoPkgIntegration.m */,
+				8B1AF8541BED81540013BE37 /* LGFileWaveIntegration.h */,
+				8B1AF8551BED81540013BE37 /* LGFileWaveIntegration.m */,
 				BEEFE6C51AEBEB1000882C89 /* LGGitIntegration.h */,
 				BEEFE6C61AEBEB1000882C89 /* LGGitIntegration.m */,
 				BEEFE6CC1AEC761F00882C89 /* LGJSSImporterIntegration.h */,
@@ -1621,6 +1623,7 @@
 				BE5E55A21B1B59D50025CFD3 /* LGTableCellViews.m in Sources */,
 				BEFC3C791A3DF16700C789E9 /* LGTestPort.m in Sources */,
 				BEE346791B15FFBC001526AD /* LGJSSDistributionPointsPrefPanel.m in Sources */,
+				BEB27FCC1BED8FF20084DA0F /* LGFileWaveIntegrationView.m in Sources */,
 				BEEFE6C31AEBCE1F00882C89 /* LGIntegrationManager.m in Sources */,
 				BE4985391AFE61C1006E5EDA /* LGServerCredentials.m in Sources */,
 				BEEFE6CF1AEC761F00882C89 /* LGJSSImporterIntegration.m in Sources */,
@@ -1632,6 +1635,7 @@
 				BEB9AF271B419F0900016D98 /* LGNotificationManager.m in Sources */,
 				BE09F65C1B2694ED00EE4AA7 /* LGAutoPkgIntegrationView.m in Sources */,
 				BEEFE6D01AEDF5BE00882C89 /* LGGitIntegration.m in Sources */,
+				BEB27FCD1BED8FF80084DA0F /* LGFileWaveIntegration.m in Sources */,
 				BE38EAA41B0CFEBB009FCBEB /* LGIntegrationsViewController.m in Sources */,
 				BECDAB9C1B24DBBC00544388 /* LGIntegrationWindowController.m in Sources */,
 				BEFC3C7D1A3DF16700C789E9 /* LGRecipeTableViewController.m in Sources */,

--- a/AutoPkgr.xcodeproj/project.pbxproj
+++ b/AutoPkgr.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		1AC98427195DF6350071CAB3 /* autopkgr.png in Resources */ = {isa = PBXBuildFile; fileRef = 1AC98425195DF6350071CAB3 /* autopkgr.png */; };
 		1AC98429195DF6DE0071CAB3 /* autopkgr_alt.png in Resources */ = {isa = PBXBuildFile; fileRef = 1AC98428195DF6DE0071CAB3 /* autopkgr_alt.png */; };
 		6A53625D1988BE59008A949C /* LGTestPort.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A53625C1988BE59008A949C /* LGTestPort.m */; };
+		8B1AF8521BED81440013BE37 /* LGFileWaveIntegrationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1AF8501BED81440013BE37 /* LGFileWaveIntegrationView.m */; settings = {ASSET_TAGS = (); }; };
+		8B1AF8531BED81440013BE37 /* LGFileWaveIntegrationView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8B1AF8511BED81440013BE37 /* LGFileWaveIntegrationView.xib */; settings = {ASSET_TAGS = (); }; };
+		8B1AF8561BED81540013BE37 /* LGFileWaveIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1AF8551BED81540013BE37 /* LGFileWaveIntegration.m */; settings = {ASSET_TAGS = (); }; };
 		8BB217F619709A2C00EF8B93 /* AutoPkgrIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 8BB217F519709A2C00EF8B93 /* AutoPkgrIcon.png */; };
 		9D2C8D4C186E66B3303DD645 /* libPods-com.lindegroup.AutoPkgr.helper.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00A11C97CD6260BB5679DA1A /* libPods-com.lindegroup.AutoPkgr.helper.a */; };
 		B8D45ABF903D8E3083FBEFAC /* libPods-AutoPkgrTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EF915ABFCFD78F7257B58CD /* libPods-AutoPkgrTests.a */; };
@@ -343,6 +346,11 @@
 		78FF6F632570F6CB7453F9D7 /* Pods-AutoPkgrTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoPkgrTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutoPkgrTests/Pods-AutoPkgrTests.release.xcconfig"; sourceTree = "<group>"; };
 		7EF915ABFCFD78F7257B58CD /* libPods-AutoPkgrTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AutoPkgrTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		82E1025CEEB73A7B5A709EE0 /* Pods-helper.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-helper.release.xcconfig"; path = "Pods/Target Support Files/Pods-helper/Pods-helper.release.xcconfig"; sourceTree = "<group>"; };
+		8B1AF84F1BED81440013BE37 /* LGFileWaveIntegrationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGFileWaveIntegrationView.h; sourceTree = "<group>"; };
+		8B1AF8501BED81440013BE37 /* LGFileWaveIntegrationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGFileWaveIntegrationView.m; sourceTree = "<group>"; };
+		8B1AF8511BED81440013BE37 /* LGFileWaveIntegrationView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LGFileWaveIntegrationView.xib; sourceTree = "<group>"; };
+		8B1AF8541BED81540013BE37 /* LGFileWaveIntegration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LGFileWaveIntegration.h; sourceTree = "<group>"; };
+		8B1AF8551BED81540013BE37 /* LGFileWaveIntegration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LGFileWaveIntegration.m; sourceTree = "<group>"; };
 		8BB217F519709A2C00EF8B93 /* AutoPkgrIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AutoPkgrIcon.png; sourceTree = "<group>"; };
 		8FDCE77563036A319CDEEBF5 /* libPods-autopkgr.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-autopkgr.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		906DD048439B1EC0FBD74F69 /* Pods-AutoPkgr.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoPkgr.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutoPkgr/Pods-AutoPkgr.release.xcconfig"; sourceTree = "<group>"; };
@@ -1007,6 +1015,9 @@
 		BE5E559C1B1A5B6E0025CFD3 /* Integration Views */ = {
 			isa = PBXGroup;
 			children = (
+				8B1AF84F1BED81440013BE37 /* LGFileWaveIntegrationView.h */,
+				8B1AF8501BED81440013BE37 /* LGFileWaveIntegrationView.m */,
+				8B1AF8511BED81440013BE37 /* LGFileWaveIntegrationView.xib */,
 				BECDAB861B234EE700544388 /* Window Controller (Integration) */,
 				BECDAB871B234F0200544388 /* Base View Controller (Integration) */,
 				BECDABA41B254E5900544388 /* LGAbsoluteManageIntegrationView.h */,
@@ -1136,6 +1147,8 @@
 		BEEFE6C41AEBEA6A00882C89 /* Integrations */ = {
 			isa = PBXGroup;
 			children = (
+				8B1AF8541BED81540013BE37 /* LGFileWaveIntegration.h */,
+				8B1AF8551BED81540013BE37 /* LGFileWaveIntegration.m */,
 				BE4DD5441B1239A300854FD8 /* Integration Manager */,
 				BEEFE6D21AF008A200882C89 /* LGIntegration Base */,
 				BE81F2211B20EFDD007D16C4 /* LGAbsoluteManageIntegration.h */,
@@ -1287,6 +1300,7 @@
 				1A2C7FAE19CC9F8300CFF472 /* codesign.py in Resources */,
 				BE38EA901B0CFE68009FCBEB /* LGInstallViewController.xib in Resources */,
 				BE32B03A1B2735DF0071778B /* LGGitIntegrationView.xib in Resources */,
+				8B1AF8531BED81440013BE37 /* LGFileWaveIntegrationView.xib in Resources */,
 				BE2D58781B32EF110042EF1E /* LocalizableAutoPkg.strings in Resources */,
 				BE38EAA51B0CFEBB009FCBEB /* LGIntegrationsViewController.xib in Resources */,
 				BE46D99C1B40EE2D00004B41 /* LGHipChatNotificationView.xib in Resources */,
@@ -1514,6 +1528,7 @@
 				BED02ADC1A194F9C00714CC2 /* NSArray+filtered.m in Sources */,
 				1AC69564195B59EE00D2BD81 /* LGAppDelegate.m in Sources */,
 				BE91A06C1B2F298900ED7501 /* AHHelpPopover.m in Sources */,
+				8B1AF8521BED81440013BE37 /* LGFileWaveIntegrationView.m in Sources */,
 				BE0BB0F71B3C68A3007F9DA5 /* LGEmailNotification.m in Sources */,
 				BEC1258619F0465C006696C4 /* LGConfigurationWindowController.m in Sources */,
 				1AC9840A195CE7D60071CAB3 /* LGConstants.m in Sources */,
@@ -1525,6 +1540,7 @@
 				BEC1258719F0465F006696C4 /* LGAutoPkgTask.m in Sources */,
 				BE025CFE19BAEF8800D36345 /* LGAutoPkgSchedule.m in Sources */,
 				BEFA4DB81B07036000764BF0 /* NSString+split.m in Sources */,
+				8B1AF8561BED81540013BE37 /* LGFileWaveIntegration.m in Sources */,
 				BE8C7D6E1A86CEF600EBD32A /* LGIntegration.m in Sources */,
 				BEDAFBB41B3B8AA500CCE9AC /* LGNotificationService.m in Sources */,
 				BE6815D51A0B18DE004AD310 /* LGUserNotification.m in Sources */,

--- a/AutoPkgr/Models/Integrations/Integration Manager/LGIntegrationManager.h
+++ b/AutoPkgr/Models/Integrations/Integration Manager/LGIntegrationManager.h
@@ -19,13 +19,14 @@
 
 #import <Foundation/Foundation.h>
 
-#import "LGIntegration.h"
-#import "LGAutoPkgIntegration.h"
-#import "LGGitIntegration.h"
-#import "LGJSSImporterIntegration.h"
-#import "LGMunkiIntegration.h"
 #import "LGAbsoluteManageIntegration.h"
+#import "LGAutoPkgIntegration.h"
+#import "LGFileWaveIntegration.h"
+#import "LGGitIntegration.h"
+#import "LGIntegration.h"
+#import "LGJSSImporterIntegration.h"
 #import "LGMacPatchIntegration.h"
+#import "LGMunkiIntegration.h"
 
 @class LGIntegration;
 

--- a/AutoPkgr/Models/Integrations/Integration Manager/LGIntegrationManager.m
+++ b/AutoPkgr/Models/Integrations/Integration Manager/LGIntegrationManager.m
@@ -36,12 +36,13 @@ static void *XXInfoStatusChange = &XXInfoStatusChange;
     dispatch_once(&token, ^{
         // As needed add additional integrations to this array.
         __integrationClasses = @[
-                          [LGAutoPkgIntegration class],
-                          [LGGitIntegration class],
-                          [LGMunkiIntegration class],
-                          [LGJSSImporterIntegration class],
                           [LGAbsoluteManageIntegration class],
+                          [LGAutoPkgIntegration class],
+                          [LGFileWaveIntegration class],
+                          [LGGitIntegration class],
+                          [LGJSSImporterIntegration class],
                           [LGMacPatchIntegration class],
+                          [LGMunkiIntegration class],
                           ];
 
         __requiredIntegrationClasses = @[

--- a/AutoPkgr/Models/Integrations/LGFileWaveIntegration.h
+++ b/AutoPkgr/Models/Integrations/LGFileWaveIntegration.h
@@ -26,8 +26,9 @@
 // This is also a good place to add custom defaults
 @interface LGFileWaveDefaults : LGDefaults
 
-@property (copy, nonatomic, readonly) NSString *DatabaseDirectory;
-
-@property (assign, nonatomic) BOOL AllowURLSDPackageImport;
+@property (copy, nonatomic) NSString *FW_SERVER_HOST;
+@property (copy, nonatomic) NSString *FW_SERVER_PORT;
+@property (copy, nonatomic) NSString *FW_ADMIN_USER;
+@property (copy, nonatomic) NSString *FW_ADMIN_PASSWORD;
 
 @end

--- a/AutoPkgr/Models/Integrations/LGFileWaveIntegration.h
+++ b/AutoPkgr/Models/Integrations/LGFileWaveIntegration.h
@@ -1,0 +1,33 @@
+//
+//  LGFileWaveIntegration.h
+//  AutoPkgr
+//
+//  Copyright 2015 Elliot Jordan.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "LGIntegration.h"
+#import "LGDefaults.h"
+
+@interface LGFileWaveIntegration : LGIntegration
+@end
+
+// This is also a good place to add custom defaults
+@interface LGFileWaveDefaults : LGDefaults
+
+@property (copy, nonatomic, readonly) NSString *DatabaseDirectory;
+
+@property (assign, nonatomic) BOOL AllowURLSDPackageImport;
+
+@end

--- a/AutoPkgr/Models/Integrations/LGFileWaveIntegration.m
+++ b/AutoPkgr/Models/Integrations/LGFileWaveIntegration.m
@@ -18,18 +18,20 @@
 //
 
 #import "LGFileWaveIntegration.h"
+#import "LGIntegration+Protocols.h"
+#import "NSString+versionCompare.h"
+
+@interface LGFileWaveIntegration () <LGIntegrationSharedProcessor>
+@end
 
 @implementation LGFileWaveIntegration
+
 + (NSString *)name {
     return @"FileWaveImporter";
 }
 
 + (NSString *)credits {
     return @"Copyright 2015 FileWave (Europe) GmbH\nhttp://www.apache.org/licenses/LICENSE-2.0";
-}
-
-+ (NSArray *)components {
-    return nil;
 }
 
 + (NSString *)defaultRepository {
@@ -43,6 +45,26 @@
 
 + (BOOL)isUninstallable {
     return YES;
+}
+
++ (BOOL)meetsRequirements:(NSError *__autoreleasing *)error {
+    NSError *err = nil;
+    NSString *fwAdmin = @"/Applications/FileWave/FileWave Admin.app";
+    NSString *bundleVersionKey = @"CFBundleShortVersionString";
+
+    NSBundle *bundle = [NSBundle bundleWithPath:fwAdmin];
+    if(!bundle){
+        err = [[self class] requirementsError:@"Filewave Admin.app is not installed"];
+    } else {
+        NSString *version = bundle.infoDictionary[bundleVersionKey];
+        if ([version version_isLessThan:@"10.0"]){
+            err = [[self class] requirementsError:@"Filewave Admin version 10.0 or greater required."];
+        }
+    }
+    if (err && error){
+        *error = err;
+    }
+    return err ? NO : YES;
 }
 
 - (void)customUninstallActions:(void (^)(NSError *))reply {

--- a/AutoPkgr/Models/Integrations/LGFileWaveIntegration.m
+++ b/AutoPkgr/Models/Integrations/LGFileWaveIntegration.m
@@ -54,11 +54,11 @@
 
     NSBundle *bundle = [NSBundle bundleWithPath:fwAdmin];
     if(!bundle){
-        err = [[self class] requirementsError:@"Filewave Admin.app is not installed"];
+        err = [[self class] requirementsError:@"FileWave Admin.app is not installed"];
     } else {
         NSString *version = bundle.infoDictionary[bundleVersionKey];
         if ([version version_isLessThan:@"10.0"]){
-            err = [[self class] requirementsError:@"Filewave Admin version 10.0 or greater required."];
+            err = [[self class] requirementsError:@"FileWave Admin version 10.0 or greater required."];
         }
     }
     if (err && error){

--- a/AutoPkgr/Models/Integrations/LGFileWaveIntegration.m
+++ b/AutoPkgr/Models/Integrations/LGFileWaveIntegration.m
@@ -18,136 +18,86 @@
 //
 
 #import "LGFileWaveIntegration.h"
-#import "LGIntegration+Protocols.h"
 
-// Define the protocols you intend to conform to...
-@interface LGFileWaveIntegration () <LGIntegrationPackageInstaller, LGIntegrationSharedProcessor>
-@end
-
-#pragma mark - Integration overrides
 @implementation LGFileWaveIntegration
-
-// Since this is defined using a protocol, it needs to be synthesized...
-// If not conforming to LGIntegrationPackageInstaller remove it.
-@synthesize gitHubInfo = _gitHubInfo;
-
-#pragma mark - Class overrides
-+ (NSString *)name
-{
++ (NSString *)name {
     return @"FileWaveImporter";
 }
 
-+ (NSString *)shortName
-{
-    return @"FileWaveImporter";
-}
 + (NSString *)credits {
     return @"Copyright 2015 FileWave (Europe) GmbH\nhttp://www.apache.org/licenses/LICENSE-2.0";
 }
 
-+ (NSURL *)homePage {
-    return [NSURL URLWithString:@"https://github.com/autopkg/filewave"];
++ (NSArray *)components {
+    return nil;
 }
 
-+ (NSString *)gitHubURL
-{
-    return @"https://api.github.com/repos/autopkg/filewave/releases";
-}
-
-+ (NSString *)defaultRepository
-{
-    // Not sure what the "Official" default repo is yet.
++ (NSString *)defaultRepository {
     return @"https://github.com/autopkg/filewave.git";
 }
 
-+ (NSArray *)components
++(NSURL *)homePage
 {
-    // If there's not a binary don't include it here!!
-    return @[[self binary]];
-}
-
-+ (NSString *)binary
-{
-    return @"/Library/AutoPkg/autopkglib/FileWaveImporter.py";
-}
-
-+ (NSArray *)packageIdentifiers
-{
-    return @[ @"com.github.autopkg.filewave.FWTool" ];
+    return [NSURL URLWithString: @"https://github.com/autopkg/filewave"];
 }
 
 + (BOOL)isUninstallable {
     return YES;
 }
 
-+ (BOOL)meetsRequirements:(NSError *__autoreleasing *)error {
-    NSFileManager *manager = [NSFileManager defaultManager];
-    NSString *lanRev = @"/Applications/LANrev Admin.app";
-
+- (void)customUninstallActions:(void (^)(NSError *))reply {
     LGFileWaveDefaults *defaults = [LGFileWaveDefaults new];
+    defaults.FW_SERVER_HOST = nil;
+    defaults.FW_SERVER_PORT = nil;
+    defaults.FW_ADMIN_USER = nil;
+    defaults.FW_ADMIN_PASSWORD = nil;
 
-    NSString *dataBase = defaults.DatabaseDirectory ?: @"~/Library/Application Support/LANrev Admin/Database/".stringByExpandingTildeInPath;
-
-    for (NSString* path in @[lanRev, dataBase]) {
-        if (![manager fileExistsAtPath:path]) {
-            if (error) {
-                *error = [[self class] requirementsError:[NSString stringWithFormat:@"Please check that %@ exists.", path]];
-            }
-            return NO;
-        }
-    }
-
-    return YES;
-}
-
-#pragma mark - Instance overrides
-- (NSString *)installedVersion
-{
-    NSString *receipt = @"/private/var/db/receipts/com.github.autopkg.filewave.FWTool.plist";
-    return [NSDictionary dictionaryWithContentsOfFile:receipt][@"PackageVersion"];
-}
-
-- (void)customInstallActions {
-    [[LGFileWaveDefaults new] setAllowURLSDPackageImport:YES];
+    // Don't forget to reply...
+    reply(nil);
 }
 
 @end
 
-#pragma mark - Defaults
+
 @implementation LGFileWaveDefaults
-
-static NSString *const kLGFileWaveDomain = @"com.poleposition-sw.lanrev_admin";
-
-- (NSString *)DatabaseDirectory {
-    return [self filewaveDomainObject:
-             NSStringFromSelector(@selector(DatabaseDirectory))];
+// URL
+- (NSString *)FW_SERVER_HOST {
+    return [self autoPkgDomainObject:NSStringFromSelector(@selector(FW_SERVER_HOST))];
 }
 
-- (void)setAllowURLSDPackageImport:(BOOL)AllowURLSDPackageImport
-{
-    [self setFileWaveDomainObject:@(AllowURLSDPackageImport)
-                                 forKey:NSStringFromSelector(@selector(AllowURLSDPackageImport))];
+-(void)setFW_SERVER_HOST:(NSString *)FW_SERVER_HOST {
+    [self setAutoPkgDomainObject:FW_SERVER_HOST forKey:NSStringFromSelector(@selector(FW_SERVER_HOST))];
 }
 
-- (BOOL)AllowURLSDPackageImport
-{
-    return [[self filewaveDomainObject:
-                      NSStringFromSelector(@selector(AllowURLSDPackageImport))] boolValue];
+// PORT
+- (NSString *)FW_SERVER_PORT {
+    return [self autoPkgDomainObject:NSStringFromSelector(@selector(FW_SERVER_PORT))];
 }
 
-- (id)filewaveDomainObject:(NSString *)key
-{
-    id value = CFBridgingRelease(
-        CFPreferencesCopyAppValue((__bridge CFStringRef)(key),
-                                  (__bridge CFStringRef)(kLGFileWaveDomain)));
-    return value;
+-(void)setFW_SERVER_PORT:(NSString *)FW_SERVER_PORT {
+    [self setAutoPkgDomainObject:FW_SERVER_PORT forKey:NSStringFromSelector(@selector(FW_SERVER_PORT))];
 }
 
-- (void)setFileWaveDomainObject:(id)object forKey:(NSString *)key
-{
-    CFPreferencesSetAppValue((__bridge CFStringRef)(key),
-                             (__bridge CFTypeRef)(object),
-                             (__bridge CFStringRef)(kLGFileWaveDomain));
+// USER
+-(NSString *)FW_ADMIN_USER{
+    return [self autoPkgDomainObject:NSStringFromSelector(@selector(FW_ADMIN_USER))];
+
 }
+
+-(void)setFW_ADMIN_USER:(NSString *)FW_ADMIN_USER {
+    [self setAutoPkgDomainObject:FW_ADMIN_USER forKey:NSStringFromSelector(@selector(FW_ADMIN_USER))];
+}
+
+// PASSWORD
+- (NSString *)FW_ADMIN_PASSWORD {
+    return [self autoPkgDomainObject:NSStringFromSelector(@selector(FW_ADMIN_PASSWORD))];
+
+}
+
+- (void)setFW_ADMIN_PASSWORD:(NSString *)FW_ADMIN_PASSWORD {
+    [self setAutoPkgDomainObject:FW_ADMIN_PASSWORD forKey:NSStringFromSelector(@selector(FW_ADMIN_PASSWORD))];
+
+}
+
 
 @end

--- a/AutoPkgr/Models/Integrations/LGFileWaveIntegration.m
+++ b/AutoPkgr/Models/Integrations/LGFileWaveIntegration.m
@@ -1,0 +1,153 @@
+//
+//  LGFileWaveIntegration.m
+//  AutoPkgr
+//
+//  Copyright 2015 Elliot Jordan.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "LGFileWaveIntegration.h"
+#import "LGIntegration+Protocols.h"
+
+// Define the protocols you intend to conform to...
+@interface LGFileWaveIntegration () <LGIntegrationPackageInstaller, LGIntegrationSharedProcessor>
+@end
+
+#pragma mark - Integration overrides
+@implementation LGFileWaveIntegration
+
+// Since this is defined using a protocol, it needs to be synthesized...
+// If not conforming to LGIntegrationPackageInstaller remove it.
+@synthesize gitHubInfo = _gitHubInfo;
+
+#pragma mark - Class overrides
++ (NSString *)name
+{
+    return @"FileWaveImporter";
+}
+
++ (NSString *)shortName
+{
+    return @"FileWaveImporter";
+}
++ (NSString *)credits {
+    return @"Copyright 2015 FileWave (Europe) GmbH\nhttp://www.apache.org/licenses/LICENSE-2.0";
+}
+
++ (NSURL *)homePage {
+    return [NSURL URLWithString:@"https://github.com/autopkg/filewave"];
+}
+
++ (NSString *)gitHubURL
+{
+    return @"https://api.github.com/repos/autopkg/filewave/releases";
+}
+
++ (NSString *)defaultRepository
+{
+    // Not sure what the "Official" default repo is yet.
+    return @"https://github.com/autopkg/filewave.git";
+}
+
++ (NSArray *)components
+{
+    // If there's not a binary don't include it here!!
+    return @[[self binary]];
+}
+
++ (NSString *)binary
+{
+    return @"/Library/AutoPkg/autopkglib/FileWaveImporter.py";
+}
+
++ (NSArray *)packageIdentifiers
+{
+    return @[ @"com.github.autopkg.filewave.FWTool" ];
+}
+
++ (BOOL)isUninstallable {
+    return YES;
+}
+
++ (BOOL)meetsRequirements:(NSError *__autoreleasing *)error {
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSString *lanRev = @"/Applications/LANrev Admin.app";
+
+    LGFileWaveDefaults *defaults = [LGFileWaveDefaults new];
+
+    NSString *dataBase = defaults.DatabaseDirectory ?: @"~/Library/Application Support/LANrev Admin/Database/".stringByExpandingTildeInPath;
+
+    for (NSString* path in @[lanRev, dataBase]) {
+        if (![manager fileExistsAtPath:path]) {
+            if (error) {
+                *error = [[self class] requirementsError:[NSString stringWithFormat:@"Please check that %@ exists.", path]];
+            }
+            return NO;
+        }
+    }
+
+    return YES;
+}
+
+#pragma mark - Instance overrides
+- (NSString *)installedVersion
+{
+    NSString *receipt = @"/private/var/db/receipts/com.github.autopkg.filewave.FWTool.plist";
+    return [NSDictionary dictionaryWithContentsOfFile:receipt][@"PackageVersion"];
+}
+
+- (void)customInstallActions {
+    [[LGFileWaveDefaults new] setAllowURLSDPackageImport:YES];
+}
+
+@end
+
+#pragma mark - Defaults
+@implementation LGFileWaveDefaults
+
+static NSString *const kLGFileWaveDomain = @"com.poleposition-sw.lanrev_admin";
+
+- (NSString *)DatabaseDirectory {
+    return [self filewaveDomainObject:
+             NSStringFromSelector(@selector(DatabaseDirectory))];
+}
+
+- (void)setAllowURLSDPackageImport:(BOOL)AllowURLSDPackageImport
+{
+    [self setFileWaveDomainObject:@(AllowURLSDPackageImport)
+                                 forKey:NSStringFromSelector(@selector(AllowURLSDPackageImport))];
+}
+
+- (BOOL)AllowURLSDPackageImport
+{
+    return [[self filewaveDomainObject:
+                      NSStringFromSelector(@selector(AllowURLSDPackageImport))] boolValue];
+}
+
+- (id)filewaveDomainObject:(NSString *)key
+{
+    id value = CFBridgingRelease(
+        CFPreferencesCopyAppValue((__bridge CFStringRef)(key),
+                                  (__bridge CFStringRef)(kLGFileWaveDomain)));
+    return value;
+}
+
+- (void)setFileWaveDomainObject:(id)object forKey:(NSString *)key
+{
+    CFPreferencesSetAppValue((__bridge CFStringRef)(key),
+                             (__bridge CFTypeRef)(object),
+                             (__bridge CFStringRef)(kLGFileWaveDomain));
+}
+
+@end

--- a/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.h
+++ b/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.h
@@ -1,0 +1,24 @@
+//
+//  LGFileWaveIntegrationView.h
+//  AutoPkgr
+//
+//  Copyright 2015 Elliot Jordan.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "LGBaseIntegrationViewController.h"
+
+@interface LGFileWaveIntegrationView : LGBaseIntegrationViewController
+
+@end

--- a/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.m
+++ b/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.m
@@ -1,0 +1,44 @@
+//
+//  LGFileWaveIntegrationView.m
+//  AutoPkgr
+//
+//  Copyright 2015 Elliot Jordan.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "LGFileWaveIntegrationView.h"
+#import "LGFileWaveIntegration.h"
+
+@interface LGFileWaveIntegrationView ()
+@property (weak) IBOutlet NSButton *enableExternalUploadBT;
+
+@end
+
+@implementation LGFileWaveIntegrationView
+
+- (void)awakeFromNib {
+    _enableExternalUploadBT.state = [LGFileWaveDefaults new].AllowURLSDPackageImport;
+}
+
+- (IBAction)enableExternalSDPackageUpload:(NSButton *)sender
+{
+    [LGFileWaveDefaults new].AllowURLSDPackageImport = sender.state;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do view setup here.
+}
+
+@end

--- a/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.m
+++ b/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.m
@@ -20,8 +20,9 @@
 
 #import "LGFileWaveIntegrationView.h"
 #import "LGFileWaveIntegration.h"
-
+#import "LGAutoPkgTask.h"
 #import "NSTextField+safeStringValue.h"
+
 @interface LGFileWaveIntegrationView ()<NSTextFieldDelegate>
 
 @property (weak) IBOutlet NSTextField *FW_SERVER_HOST;
@@ -60,8 +61,19 @@
 
 }
 
-- (void)FWToolVerify:(NSButton *)sender {
+- (IBAction)FWToolVerify:(NSButton *)sender {
     // Run `autopkg run FWTool.recipe` and make sure that it verifies.
+    sender.state = NSOffState;
+    [self.progressSpinner startAnimation:nil];
+    [LGAutoPkgTask runRecipes:@[@"FWTool.filewave.recipe"]
+                     progress:nil
+                        reply:^(NSDictionary *results, NSError *error) {
+                            sender.state = NSOnState;
+                            [self.progressSpinner stopAnimation:nil];
+                            if (error){
+                                [NSApp presentError:error];
+                            }
+    }];
 }
 
 - (void)controlTextDidChange:(NSNotification *)notification {

--- a/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.m
+++ b/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.m
@@ -17,28 +17,74 @@
 //  limitations under the License.
 //
 
+
 #import "LGFileWaveIntegrationView.h"
 #import "LGFileWaveIntegration.h"
 
-@interface LGFileWaveIntegrationView ()
-@property (weak) IBOutlet NSButton *enableExternalUploadBT;
+#import "NSTextField+safeStringValue.h"
+@interface LGFileWaveIntegrationView ()<NSTextFieldDelegate>
+
+@property (weak) IBOutlet NSTextField *FW_SERVER_HOST;
+@property (weak) IBOutlet NSTextField *FW_SERVER_PORT;
+@property (weak) IBOutlet NSTextField *FW_ADMIN_USER;
+@property (weak) IBOutlet NSSecureTextField *FW_ADMIN_PASSWORD;
+@property (weak) IBOutlet NSButton *FWToolVerify;
 
 @end
 
-@implementation LGFileWaveIntegrationView
-
-- (void)awakeFromNib {
-    _enableExternalUploadBT.state = [LGFileWaveDefaults new].AllowURLSDPackageImport;
+@implementation LGFileWaveIntegrationView {
+    LGFileWaveDefaults *_defaults;
 }
 
-- (IBAction)enableExternalSDPackageUpload:(NSButton *)sender
+- (void)viewDidLoad
 {
-    [LGFileWaveDefaults new].AllowURLSDPackageImport = sender.state;
-}
-
-- (void)viewDidLoad {
     [super viewDidLoad];
     // Do view setup here.
 }
 
+- (void)awakeFromNib
+{
+    _defaults = [[LGFileWaveDefaults alloc] init];
+
+    _FW_SERVER_HOST.delegate = self;
+    _FW_SERVER_HOST.safe_stringValue = _defaults.FW_SERVER_HOST;
+
+    _FW_SERVER_PORT.delegate = self;
+    _FW_SERVER_PORT.safe_stringValue = _defaults.FW_SERVER_PORT;
+
+    _FW_ADMIN_USER.delegate = self;
+    _FW_ADMIN_USER.safe_stringValue = _defaults.FW_ADMIN_USER;
+
+    _FW_ADMIN_PASSWORD.delegate = self;
+    _FW_ADMIN_PASSWORD.safe_stringValue = _defaults.FW_ADMIN_PASSWORD;
+
+}
+
+- (void)FWToolVerify:(NSButton *)sender {
+    // Run `autopkg run FWTool.recipe` and make sure that it verifies.
+}
+
+- (void)controlTextDidChange:(NSNotification *)notification {
+    NSString *string = [notification.object stringValue];
+
+    // URL
+    if ([notification.object isEqualTo:_FW_SERVER_HOST]) {
+        _defaults.FW_SERVER_HOST = string;
+    }
+
+    // Port
+    if ([notification.object isEqualTo:_FW_SERVER_PORT]) {
+        _defaults.FW_SERVER_PORT = string;
+    }
+
+    // User
+    else if ([notification.object isEqualTo:_FW_ADMIN_USER]) {
+        _defaults.FW_ADMIN_USER = string;
+    }
+
+    // Password
+    else if ([notification.object isEqualTo:_FW_ADMIN_PASSWORD]) {
+        _defaults.FW_ADMIN_PASSWORD = string;
+    }
+}
 @end

--- a/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.xib
+++ b/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.xib
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="LGFileWaveIntegrationView">
+            <connections>
+                <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="Hz6-mo-xeY">
+            <rect key="frame" x="0.0" y="0.0" width="513" height="216"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yRa-44-e8a">
+                    <rect key="frame" x="208" y="174" width="285" height="22"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="ZFA-IW-McZ">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JEr-CG-Pgl">
+                    <rect key="frame" x="18" y="177" width="184" height="17"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="FileWave Server Hostname:" id="PWR-ok-oY7">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EHv-BV-WGq">
+                    <rect key="frame" x="208" y="142" width="285" height="22"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="hgm-TZ-yGN">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LdN-lb-Mxz">
+                    <rect key="frame" x="18" y="145" width="184" height="17"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="FileWave Server Port:" id="cPZ-Tn-8JV">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tjf-aD-P4A">
+                    <rect key="frame" x="208" y="110" width="285" height="22"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="IwY-8t-4ra">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="x24-eE-iR0">
+                    <rect key="frame" x="18" y="113" width="184" height="17"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="Aq0-20-9LL">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4OS-cf-Fch">
+                    <rect key="frame" x="208" y="78" width="285" height="22"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="iP7-68-fqO">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1ll-8f-8Td">
+                    <rect key="frame" x="18" y="81" width="184" height="17"/>
+                    <animations/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="6Gk-Op-HAD">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1xU-M6-bXt">
+                    <rect key="frame" x="329" y="36" width="145" height="28"/>
+                    <animations/>
+                    <buttonCell key="cell" type="push" title="Verify" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Cpt-g9-6qH">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="smallSystem"/>
+                    </buttonCell>
+                </button>
+                <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nCR-dN-Nut">
+                    <rect key="frame" x="477" y="40" width="16" height="23"/>
+                    <animations/>
+                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="NSStatusNone" id="MP1-Qb-Bwf"/>
+                </imageView>
+                <progressIndicator hidden="YES" wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Wpx-Eb-uhs">
+                    <rect key="frame" x="477" y="43" width="16" height="16"/>
+                    <animations/>
+                </progressIndicator>
+            </subviews>
+            <animations/>
+            <point key="canvasLocation" x="148.5" y="126"/>
+        </customView>
+    </objects>
+    <resources>
+        <image name="NSStatusNone" width="16" height="16"/>
+    </resources>
+</document>

--- a/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.xib
+++ b/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.xib
@@ -16,7 +16,7 @@
             <rect key="frame" x="0.0" y="0.0" width="513" height="216"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yRa-44-e8a">
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yRa-44-e8a">
                     <rect key="frame" x="208" y="174" width="285" height="22"/>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="ZFA-IW-McZ">
@@ -25,8 +25,11 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JEr-CG-Pgl">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JEr-CG-Pgl">
                     <rect key="frame" x="18" y="177" width="184" height="17"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="180" id="jZr-T3-iLy"/>
+                    </constraints>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="FileWave Server Hostname:" id="PWR-ok-oY7">
                         <font key="font" metaFont="system"/>
@@ -34,7 +37,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EHv-BV-WGq">
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EHv-BV-WGq">
                     <rect key="frame" x="208" y="142" width="285" height="22"/>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="hgm-TZ-yGN">
@@ -43,8 +46,11 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LdN-lb-Mxz">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LdN-lb-Mxz">
                     <rect key="frame" x="18" y="145" width="184" height="17"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="180" id="kdx-p4-3Ae"/>
+                    </constraints>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="FileWave Server Port:" id="cPZ-Tn-8JV">
                         <font key="font" metaFont="system"/>
@@ -52,7 +58,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tjf-aD-P4A">
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Tjf-aD-P4A">
                     <rect key="frame" x="208" y="110" width="285" height="22"/>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="IwY-8t-4ra">
@@ -61,8 +67,11 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="x24-eE-iR0">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="x24-eE-iR0">
                     <rect key="frame" x="18" y="113" width="184" height="17"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="180" id="9Zx-Pm-niG"/>
+                    </constraints>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="Aq0-20-9LL">
                         <font key="font" metaFont="system"/>
@@ -70,7 +79,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4OS-cf-Fch">
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4OS-cf-Fch">
                     <rect key="frame" x="208" y="78" width="285" height="22"/>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="iP7-68-fqO">
@@ -79,8 +88,11 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1ll-8f-8Td">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1ll-8f-8Td">
                     <rect key="frame" x="18" y="81" width="184" height="17"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="180" id="rVO-X8-HU4"/>
+                    </constraints>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="6Gk-Op-HAD">
                         <font key="font" metaFont="system"/>
@@ -88,24 +100,63 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1xU-M6-bXt">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1xU-M6-bXt">
                     <rect key="frame" x="329" y="36" width="145" height="28"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="135" id="8bf-Yz-Uaw"/>
+                    </constraints>
                     <animations/>
                     <buttonCell key="cell" type="push" title="Verify" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Cpt-g9-6qH">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystem"/>
                     </buttonCell>
                 </button>
-                <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nCR-dN-Nut">
+                <imageView translatesAutoresizingMaskIntoConstraints="NO" id="nCR-dN-Nut">
                     <rect key="frame" x="477" y="40" width="16" height="23"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="16" id="2bZ-Hr-cYB"/>
+                        <constraint firstAttribute="height" constant="23" id="cj9-kG-VtC"/>
+                    </constraints>
                     <animations/>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="NSStatusNone" id="MP1-Qb-Bwf"/>
                 </imageView>
-                <progressIndicator hidden="YES" wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Wpx-Eb-uhs">
+                <progressIndicator hidden="YES" wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Wpx-Eb-uhs">
                     <rect key="frame" x="477" y="43" width="16" height="16"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="16" id="BPj-Fl-M2f"/>
+                        <constraint firstAttribute="height" constant="16" id="Kbh-VO-jqB"/>
+                    </constraints>
                     <animations/>
                 </progressIndicator>
             </subviews>
+            <constraints>
+                <constraint firstItem="x24-eE-iR0" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="2d7-yU-OVe"/>
+                <constraint firstItem="nCR-dN-Nut" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="153" id="2wO-VK-2r2"/>
+                <constraint firstAttribute="trailing" secondItem="1xU-M6-bXt" secondAttribute="trailing" constant="44" id="A7X-DB-3EE"/>
+                <constraint firstItem="4OS-cf-Fch" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="116" id="CUB-kq-WvW"/>
+                <constraint firstAttribute="trailing" secondItem="Tjf-aD-P4A" secondAttribute="trailing" constant="20" id="FLp-Qv-Y6x"/>
+                <constraint firstItem="1ll-8f-8Td" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="Gz5-5w-Fw7"/>
+                <constraint firstItem="JEr-CG-Pgl" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="22" id="MtR-eo-55l"/>
+                <constraint firstItem="Tjf-aD-P4A" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="208" id="OTv-I8-koN"/>
+                <constraint firstAttribute="trailing" secondItem="EHv-BV-WGq" secondAttribute="trailing" constant="20" id="P48-y4-NvM"/>
+                <constraint firstAttribute="trailing" secondItem="nCR-dN-Nut" secondAttribute="trailing" constant="20" id="TCP-7h-npC"/>
+                <constraint firstItem="yRa-44-e8a" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="208" id="TmW-rN-S1j"/>
+                <constraint firstItem="1ll-8f-8Td" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="118" id="Wy9-7c-yrs"/>
+                <constraint firstItem="4OS-cf-Fch" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="208" id="Xff-pP-UeA"/>
+                <constraint firstItem="EHv-BV-WGq" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="52" id="bE5-lh-mIL"/>
+                <constraint firstItem="1xU-M6-bXt" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="156" id="bss-Os-6fH"/>
+                <constraint firstItem="x24-eE-iR0" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="86" id="dg1-oW-o6w"/>
+                <constraint firstItem="LdN-lb-Mxz" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="fSY-hO-j7p"/>
+                <constraint firstItem="yRa-44-e8a" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="20" id="gFQ-ua-Mfh"/>
+                <constraint firstAttribute="trailing" secondItem="yRa-44-e8a" secondAttribute="trailing" constant="20" id="jSg-bd-X5s"/>
+                <constraint firstItem="Tjf-aD-P4A" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="84" id="krJ-Nk-xtl"/>
+                <constraint firstItem="Wpx-Eb-uhs" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="157" id="nJv-Sw-Bqf"/>
+                <constraint firstAttribute="trailing" secondItem="4OS-cf-Fch" secondAttribute="trailing" constant="20" id="qZl-rF-XPA"/>
+                <constraint firstItem="EHv-BV-WGq" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="208" id="tzr-QZ-ldd"/>
+                <constraint firstAttribute="trailing" secondItem="Wpx-Eb-uhs" secondAttribute="trailing" constant="20" id="w1q-l4-sha"/>
+                <constraint firstItem="JEr-CG-Pgl" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="wgI-rv-oJj"/>
+                <constraint firstItem="LdN-lb-Mxz" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="54" id="xxI-Jn-tXk"/>
+            </constraints>
             <animations/>
             <point key="canvasLocation" x="148.5" y="126"/>
         </customView>

--- a/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.xib
+++ b/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.xib
@@ -7,6 +7,9 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="LGFileWaveIntegrationView">
             <connections>
+                <outlet property="FW_ADMIN_USER" destination="Tjf-aD-P4A" id="toF-wa-j5R"/>
+                <outlet property="FW_SERVER_HOST" destination="yRa-44-e8a" id="GZk-O4-l19"/>
+                <outlet property="FW_SERVER_PORT" destination="EHv-BV-WGq" id="UMB-e6-lpp"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
         </customObject>

--- a/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.xib
+++ b/AutoPkgr/Views-Controllers-XIB/Integration Views/LGFileWaveIntegrationView.xib
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="LGFileWaveIntegrationView">
             <connections>
+                <outlet property="FW_ADMIN_PASSWORD" destination="4OS-cf-Fch" id="5mp-6f-QYu"/>
                 <outlet property="FW_ADMIN_USER" destination="Tjf-aD-P4A" id="toF-wa-j5R"/>
                 <outlet property="FW_SERVER_HOST" destination="yRa-44-e8a" id="GZk-O4-l19"/>
                 <outlet property="FW_SERVER_PORT" destination="EHv-BV-WGq" id="UMB-e6-lpp"/>
+                <outlet property="progressSpinner" destination="Wpx-Eb-uhs" id="duU-eA-7wT"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
         </customObject>
@@ -82,7 +84,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4OS-cf-Fch">
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4OS-cf-Fch" customClass="NSSecureTextField">
                     <rect key="frame" x="208" y="78" width="285" height="22"/>
                     <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="iP7-68-fqO">
@@ -113,6 +115,9 @@
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystem"/>
                     </buttonCell>
+                    <connections>
+                        <action selector="FWToolVerify:" target="-2" id="DIW-BH-goe"/>
+                    </connections>
                 </button>
                 <imageView translatesAutoresizingMaskIntoConstraints="NO" id="nCR-dN-Nut">
                     <rect key="frame" x="477" y="40" width="16" height="23"/>

--- a/AutoPkgr/Views-Controllers-XIB/Tab Views/LGIntegrationsViewController.m
+++ b/AutoPkgr/Views-Controllers-XIB/Tab Views/LGIntegrationsViewController.m
@@ -18,15 +18,16 @@
 //  limitations under the License.
 //
 
-#import "LGIntegrationsViewController.h"
-#import "LGIntegrationManager.h"
-#import "LGAutoPkgIntegrationView.h"
-#import "LGGitIntegrationView.h"
-#import "LGJSSImporterIntegrationView.h"
-#import "LGMunkiIntegrationView.h"
 #import "LGAbsoluteManageIntegrationView.h"
-#import "LGMacPatchIntegrationView.h"
+#import "LGAutoPkgIntegrationView.h"
+#import "LGFileWaveIntegrationView.h"
+#import "LGGitIntegrationView.h"
+#import "LGIntegrationManager.h"
+#import "LGIntegrationsViewController.h"
 #import "LGIntegrationWindowController.h"
+#import "LGJSSImporterIntegrationView.h"
+#import "LGMacPatchIntegrationView.h"
+#import "LGMunkiIntegrationView.h"
 #import "LGTableCellViews.h"
 
 #import "NSOpenPanel+typeChooser.h"


### PR DESCRIPTION
@eahrold — I took a crack at creating the files necessary for the FileWave integration. I used the AbsoluteManageIntegration files as a starting point, and basically did a find/replace on them. I also created a new xib, which is pretty much good to go.

![screen shot 2015-11-06 at 5 11 18 pm](https://cloud.githubusercontent.com/assets/7801391/11012510/7100aefc-84a9-11e5-939a-f058d5a935b0.png)

Here are the things that need to work before we can merge back into the 1.3.3 branch:

- [ ] An __Install FileWaveImporter__ button on the integrations tab, which does `autopkg repo-add filewave`.
- [ ] Whatever is entered into the __FileWave Server Hostname__ field needs to find its way into the AutoPkg preferences file. (e.g. `defaults write com.github.autopkg FW_SERVER_HOST filewave.pretendco.com`)
- [ ] Whatever is entered into the __FileWave Server Port__ field needs to find its way into the AutoPkg preferences file. (e.g. `defaults write com.github.autopkg FW_SERVER_PORT 20016`)
- [ ] Whatever is entered into the __Username__ field needs to find its way into the AutoPkg preferences file. (e.g. `defaults write com.github.autopkg FW_ADMIN_USER fwadmin`)
- [ ] Whatever is entered into the __Password__ field needs to find its way into the AutoPkg preferences file. (e.g. `defaults write com.github.autopkg FW_ADMIN_PASSWORD F1L3W4V3`)
- [ ] When the __Verify__ button is clicked, we should run `autopkg run FWTool.filewave` and make sure the "Fw Message" returned is equal to `VALIDATION OK` (as shown [here](https://github.com/autopkg/filewave#validation-of-the-setup)). While we're waiting for the results, we can spin the spinner. If the OK message comes back, the indicator turns green. Otherwise, it turns red.

No particular deadline for this, but I know people will be knocking on our door soon. :-)

I'll work on the xib constraints soon.