### PR TITLE
RECIPE_OVERRIDE_DIRS is an array of strings, not a string

### DIFF
--- a/AutoPkgr/Utility/LGDefaults.m
+++ b/AutoPkgr/Utility/LGDefaults.m
@@ -231,12 +231,12 @@
 }
 
 #pragma mark
-- (NSString *)autoPkgRecipeOverridesDir
+- (NSArray *)autoPkgRecipeOverridesDir
 {
     return [self autoPkgDomainObject:@"RECIPE_OVERRIDE_DIRS"];
 }
 
-- (void)setAutoPkgRecipeOverridesDir:(NSString *)autoPkgRecipeOverridesDir
+- (void)setAutoPkgRecipeOverridesDir:(NSArray *)autoPkgRecipeOverridesDir
 {
     [self setAutoPkgDomainObject:autoPkgRecipeOverridesDir forKey:@"RECIPE_OVERRIDE_DIRS"];
 }


### PR DESCRIPTION
For a long time, I've seen AutoPkgr get stuck in this state upon launching, where none of the expected tabs except for Install appear:

<img width="769" alt="image" src="https://user-images.githubusercontent.com/7801391/72788402-b8f80400-3be6-11ea-8cc5-3040180ce2b8.png">

I knew it had something to do with the AutoPkg preferences, because if I set the ~/Library/Preferences/com.github.autopkg.plist file aside, `killall cfprefsd`, and relaunched AutoPkgr, AutoPkgr would be back to normal:

<img width="769" alt="image" src="https://user-images.githubusercontent.com/7801391/72788520-eb096600-3be6-11ea-9d84-96ecbcd33f6f.png">

Now I've finally drilled in and figured out what was causing the issue, and it goes all the way back to [AutoPkgr 1.0.2](https://github.com/lindegroup/autopkgr/commit/4d6db66f20eb8dd2a0d21c7283cac8b238b12899#diff-012c6908c5244ff43d7add5464a1e8c2)... the `RECIPE_OVERRIDE_DIRS` preference key should be an array of strings, but AutoPkgr expects it to be a single string.

I've made the most obvious change I could to fix this behavior, but I don't have the tools needed to build and test the result. The UI for customizing the recipe override directory should probably be modified or removed, since the UI makes it look like a string and is unable to display more than one path.

I've targeted the 1.5.3-dev branch, because I think that UI work is going to be needed before this can be merged to master.