### PR TITLE
Fix blank screen on startup if AutoPkg missing

### DIFF
--- a/AutoPkgr/Models/Integrations/LGAutoPkgIntegration.m
+++ b/AutoPkgr/Models/Integrations/LGAutoPkgIntegration.m
@@ -63,6 +63,11 @@
     return NO;
 }
 
++ (BOOL)isInstalled
+{
+    return [[NSFileManager defaultManager] isExecutableFileAtPath:@"/usr/local/autopkg/python"];
+}
+
 #pragma mark - Instance overrides
 - (NSString *)installedVersion
 {


### PR DESCRIPTION
This pull request should resolve the long-standing issue that results in a blank initial AutoPkgr window if AutoPkgr is launched without AutoPkg (or more specifically, `/usr/local/autopkg/python`) installed first.

This is handled by checking for the AutoPkg python executable and returning a boolean value indicating AutoPkg is not installed if the executable is absent. This allows AutoPkgr to load as expected, and indicate that AutoPkg is not yet installed:

<img width="769" height="622" alt="Screenshot 2026-01-31 at 2 59 59 PM" src="https://github.com/user-attachments/assets/a3bdd69a-4b77-45b6-a2c9-147bbf82d875" />

Subsequently clicking on any of the other tabs (Repos & Recipes, Schedule, Notifications, or Integrations) will result in a clear alert indicating that both AutoPkg and Git are required to use AutoPkgr. Both AutoPkg and Git can be easily installed from the Install tab.

<img width="769" height="622" alt="Screenshot 2026-01-31 at 3 02 56 PM" src="https://github.com/user-attachments/assets/85b22715-910d-434c-b86a-cde596f1f98b" />

Resolves: #718, #696, #679