### PR TITLE
Detect installed Munki version from package receipts

### DIFF
--- a/AutoPkgr/Models/Integrations/LGMunkiIntegration.h
+++ b/AutoPkgr/Models/Integrations/LGMunkiIntegration.h
@@ -21,6 +21,16 @@
 #import "LGIntegration.h"
 
 @interface LGMunkiIntegration : LGIntegration
+
+// Sub-package identifiers used to determine the installed Munki metapackage version.
++ (NSArray *)packageIdentifiers;
+
+// Returns the highest PackageVersion across all Munki sub-package receipts in
+// the given directory, or nil if none are present. -installedVersion delegates
+// here with /private/var/db/receipts/; the directory is parameterized so tests
+// can point it at a temp dir.
++ (NSString *)installedVersionFromReceiptsInDirectory:(NSString *)directory;
+
 @end
 
 // This is also a good place to add custom defaults.

--- a/AutoPkgr/Models/Integrations/LGMunkiIntegration.m
+++ b/AutoPkgr/Models/Integrations/LGMunkiIntegration.m
@@ -70,8 +70,7 @@ static NSString *const kLGMunkiimportDomain = @"com.googlecode.munki.munkiimport
               @"com.googlecode.munki.app",
               @"com.googlecode.munki.app_usage",
               @"com.googlecode.munki.core",
-              @"com.googlecode.munki.launchd",
-              @"com.googlecode.munki.pythonlibs" ];
+              @"com.googlecode.munki.launchd" ];
 }
 
 + (BOOL)isUninstallable

--- a/AutoPkgr/Models/Integrations/LGMunkiIntegration.m
+++ b/AutoPkgr/Models/Integrations/LGMunkiIntegration.m
@@ -92,13 +92,18 @@ static NSString *const kLGMunkiimportDomain = @"com.googlecode.munki.munkiimport
 #pragma mark - Instance overrides
 - (NSString *)installedVersion
 {
+    return [[self class] installedVersionFromReceiptsInDirectory:@"/private/var/db/receipts/"];
+}
+
++ (NSString *)installedVersionFromReceiptsInDirectory:(NSString *)directory
+{
     // Use the highest version across all sub-package receipts, matching how the
     // Munki build script determines the metapackage version. Individual tool
     // versions (e.g. munkiimport --version) can lag behind the metapackage when
     // only non-CLI components changed in a release.
     NSString *highestVersion = nil;
-    for (NSString *identifier in [[self class] packageIdentifiers]) {
-        NSString *receiptPath = [[@"/private/var/db/receipts/" stringByAppendingPathComponent:identifier] stringByAppendingPathExtension:@"plist"];
+    for (NSString *identifier in [self packageIdentifiers]) {
+        NSString *receiptPath = [[directory stringByAppendingPathComponent:identifier] stringByAppendingPathExtension:@"plist"];
         NSDictionary *receiptDict = [NSDictionary dictionaryWithContentsOfFile:receiptPath];
         NSString *version = receiptDict[@"PackageVersion"];
         if (version && (!highestVersion || [version version_isGreaterThan:highestVersion])) {

--- a/AutoPkgr/Models/Integrations/LGMunkiIntegration.m
+++ b/AutoPkgr/Models/Integrations/LGMunkiIntegration.m
@@ -19,6 +19,7 @@
 
 #import "LGIntegration+Protocols.h"
 #import "LGMunkiIntegration.h"
+#import "NSString+versionCompare.h"
 
 static NSString *const kLGMunkiimportDomain = @"com.googlecode.munki.munkiimport";
 // Define the protocols you intend to conform to.
@@ -67,9 +68,10 @@ static NSString *const kLGMunkiimportDomain = @"com.googlecode.munki.munkiimport
 {
     return @[ @"com.googlecode.munki.admin",
               @"com.googlecode.munki.app",
+              @"com.googlecode.munki.app_usage",
               @"com.googlecode.munki.core",
               @"com.googlecode.munki.launchd",
-              @"com.googlecode.munki.munkiwebadmin-scripts" ];
+              @"com.googlecode.munki.pythonlibs" ];
 }
 
 + (BOOL)isUninstallable
@@ -91,7 +93,20 @@ static NSString *const kLGMunkiimportDomain = @"com.googlecode.munki.munkiimport
 #pragma mark - Instance overrides
 - (NSString *)installedVersion
 {
-    return [[self versionTaskWithExec:[[self class] binary] arguments:@[ @"--version" ]] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    // Use the highest version across all sub-package receipts, matching how the
+    // Munki build script determines the metapackage version. Individual tool
+    // versions (e.g. munkiimport --version) can lag behind the metapackage when
+    // only non-CLI components changed in a release.
+    NSString *highestVersion = nil;
+    for (NSString *identifier in [[self class] packageIdentifiers]) {
+        NSString *receiptPath = [[@"/private/var/db/receipts/" stringByAppendingPathComponent:identifier] stringByAppendingPathExtension:@"plist"];
+        NSDictionary *receiptDict = [NSDictionary dictionaryWithContentsOfFile:receiptPath];
+        NSString *version = receiptDict[@"PackageVersion"];
+        if (version && (!highestVersion || [version version_isGreaterThan:highestVersion])) {
+            highestVersion = version;
+        }
+    }
+    return highestVersion;
 }
 
 - (NSString *)remoteVersion

--- a/AutoPkgrTests/AutoPkgrTests.m
+++ b/AutoPkgrTests/AutoPkgrTests.m
@@ -22,6 +22,7 @@
 #import "LGGitHubJSONLoader.h"
 #import "LGInstaller.h"
 #import "LGIntegrationManager.h"
+#import "NSString+versionCompare.h"
 #import <XCTest/XCTest.h>
 
 #import "LGAutoPkgErrorHandler.h"
@@ -247,6 +248,157 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
     XCTAssertFalse([@"0.4.2" version_isLessThanOrEqualTo:@"0.4.1"], @"wrong");
     XCTAssertTrue([@"0.4.1" version_isLessThanOrEqualTo:@"0.4.1"], @"wrong");
     XCTAssertTrue([@"0.4.1" version_isLessThanOrEqualTo:@"0.4.2"], @"wrong");
+}
+
+#pragma mark - Munki version detection
+
+- (NSArray *)munkiPackageIdentifiers
+{
+    return @[ @"com.googlecode.munki.admin",
+              @"com.googlecode.munki.app",
+              @"com.googlecode.munki.app_usage",
+              @"com.googlecode.munki.core",
+              @"com.googlecode.munki.launchd" ];
+}
+
+- (NSString *)munkiVersionFromReceiptsInDirectory:(NSString *)dir
+{
+    NSString *highestVersion = nil;
+    for (NSString *identifier in [self munkiPackageIdentifiers]) {
+        NSString *receiptPath = [[dir stringByAppendingPathComponent:identifier] stringByAppendingPathExtension:@"plist"];
+        NSDictionary *receiptDict = [NSDictionary dictionaryWithContentsOfFile:receiptPath];
+        NSString *version = receiptDict[@"PackageVersion"];
+        if (version && (!highestVersion || [version version_isGreaterThan:highestVersion])) {
+            highestVersion = version;
+        }
+    }
+    return highestVersion;
+}
+
+- (void)writeReceiptPlistAtPath:(NSString *)path version:(NSString *)version
+{
+    NSDictionary *receipt = @{
+        @"PackageIdentifier" : path.lastPathComponent.stringByDeletingPathExtension,
+        @"PackageVersion" : version,
+        @"InstallDate" : [NSDate date],
+        @"InstallPrefixPath" : @"/",
+    };
+    [receipt writeToFile:path atomically:YES];
+}
+
+- (void)testMunkiReceiptVersionMatchesMetapackage
+{
+    // Munki v6.6.0: metapackage was munkitools-6.6.0.4690.pkg but munkiimport
+    // --version reported 6.6.0.4686, because the code/client rev count was lower
+    // than the code/apps rev count used for the metapackage build number.
+    // Reading receipts should yield the correct metapackage version.
+    NSString *tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:
+                        [[NSUUID UUID] UUIDString]];
+    [[NSFileManager defaultManager] createDirectoryAtPath:tmpDir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+
+    NSString *metapackageVersion = @"6.6.0.4690";
+    for (NSString *identifier in [self munkiPackageIdentifiers]) {
+        NSString *path = [[tmpDir stringByAppendingPathComponent:identifier]
+                          stringByAppendingPathExtension:@"plist"];
+        if ([identifier isEqualToString:@"com.googlecode.munki.launchd"]) {
+            [self writeReceiptPlistAtPath:path version:@"6.5.0.4265"];
+        } else {
+            [self writeReceiptPlistAtPath:path version:metapackageVersion];
+        }
+    }
+
+    NSString *detectedVersion = [self munkiVersionFromReceiptsInDirectory:tmpDir];
+    XCTAssertEqualObjects(detectedVersion, metapackageVersion,
+        @"Receipt-based detection should return the metapackage version");
+
+    // munkiimport --version would have returned 6.6.0.4686 for this release,
+    // which is less than the metapackage version and would falsely trigger an update.
+    NSString *munkiimportVersion = @"6.6.0.4686";
+    XCTAssertTrue([metapackageVersion version_isGreaterThan:munkiimportVersion],
+        @"munkiimport --version (4686) is less than the metapackage (4690)");
+    XCTAssertFalse([metapackageVersion version_isGreaterThan:detectedVersion],
+        @"Receipt-based version should not falsely trigger an update");
+
+    [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
+}
+
+- (void)testMunkiReceiptVersionWithDivergentBuildNumbers
+{
+    // Simulate real-world receipts where sub-packages have different build numbers.
+    // The launchd package often lags behind because its content changes less frequently.
+    NSString *tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:
+                        [[NSUUID UUID] UUIDString]];
+    [[NSFileManager defaultManager] createDirectoryAtPath:tmpDir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+
+    NSDictionary *receiptVersions = @{
+        @"com.googlecode.munki.admin"     : @"7.1.2.5700",
+        @"com.googlecode.munki.app"       : @"7.1.2.5700",
+        @"com.googlecode.munki.app_usage" : @"7.1.2.5700",
+        @"com.googlecode.munki.core"      : @"7.1.2.5700",
+        @"com.googlecode.munki.launchd"   : @"7.0.0.5320",
+    };
+    for (NSString *identifier in receiptVersions) {
+        NSString *path = [[tmpDir stringByAppendingPathComponent:identifier]
+                          stringByAppendingPathExtension:@"plist"];
+        [self writeReceiptPlistAtPath:path version:receiptVersions[identifier]];
+    }
+
+    NSString *detectedVersion = [self munkiVersionFromReceiptsInDirectory:tmpDir];
+    XCTAssertEqualObjects(detectedVersion, @"7.1.2.5700",
+        @"Should return the highest version across all receipts");
+
+    [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
+}
+
+- (void)testMunkiReceiptVersionExcludesPythonlibs
+{
+    // The pythonlibs receipt can have a completely different version (e.g. 6.7.0.5293
+    // when the rest of Munki is 7.1.2.5700). Verify it is excluded from the
+    // identifier list so it cannot poison the version detection.
+    NSArray *identifiers = [self munkiPackageIdentifiers];
+    XCTAssertFalse([identifiers containsObject:@"com.googlecode.munki.pythonlibs"],
+        @"pythonlibs must not be in packageIdentifiers");
+}
+
+- (void)testMunkiReceiptVersionNoFalseUpdateForV660
+{
+    // Munki v6.6.0: the GitHub release asset is munkitools-6.6.0.4690.pkg, but
+    // munkiimport --version reports 6.6.0.4686 due to divergent build numbers.
+    // Using receipts yields 6.6.0.4690, matching the remote version correctly.
+    NSString *remoteVersion = @"6.6.0.4690";
+    NSString *munkiimportVersion = @"6.6.0.4686";
+    NSString *receiptVersion = @"6.6.0.4690";
+
+    // munkiimport --version reports a lower build number than the metapackage
+    XCTAssertTrue([remoteVersion version_isGreaterThan:munkiimportVersion],
+        @"munkiimport --version would falsely indicate an update is available");
+
+    // Receipt-based detection matches the metapackage version
+    XCTAssertFalse([remoteVersion version_isGreaterThan:receiptVersion],
+        @"Receipt-based version correctly matches, no false update");
+}
+
+- (void)testMunkiReceiptVersionMissingReceipts
+{
+    // When no receipts exist (Munki not installed), the method should return nil.
+    NSString *tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:
+                        [[NSUUID UUID] UUIDString]];
+    [[NSFileManager defaultManager] createDirectoryAtPath:tmpDir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+
+    NSString *detectedVersion = [self munkiVersionFromReceiptsInDirectory:tmpDir];
+    XCTAssertNil(detectedVersion,
+        @"Should return nil when no receipt plists exist");
+
+    [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
 }
 
 - (void)testLoader

--- a/AutoPkgrTests/AutoPkgrTests.m
+++ b/AutoPkgrTests/AutoPkgrTests.m
@@ -29,6 +29,7 @@
 #import "LGAutoPkgRecipeListManager.h"
 #import "LGAutoPkgReport.h"
 #import "LGAutoPkgTask.h"
+#import "LGMunkiIntegration.h"
 
 #import "LGPasswords.h"
 #import "LGServerCredentials.h"
@@ -54,18 +55,38 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
 
 @implementation AutoPkgrTests {
     LGUserNotificationsDelegate *_noteDelegate;
+    NSMutableArray *_tempDirs;
 }
 
 - (void)setUp
 {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
+    _tempDirs = [NSMutableArray array];
 }
 
 - (void)tearDown
 {
     // Put teardown code here. This method is called after the invocation of each test method in the class.
+    // Remove any temp dirs created via -createTempDirectory, even if a test
+    // assertion failed before reaching its own cleanup.
+    for (NSString *dir in _tempDirs) {
+        [[NSFileManager defaultManager] removeItemAtPath:dir error:nil];
+    }
     [super tearDown];
+}
+
+// Creates a unique temp directory that is automatically removed in -tearDown.
+- (NSString *)createTempDirectory
+{
+    NSString *tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:
+                        [[NSUUID UUID] UUIDString]];
+    [[NSFileManager defaultManager] createDirectoryAtPath:tmpDir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    [_tempDirs addObject:tmpDir];
+    return tmpDir;
 }
 
 #pragma mark - LGAutoPkgTask
@@ -252,29 +273,6 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
 
 #pragma mark - Munki version detection
 
-- (NSArray *)munkiPackageIdentifiers
-{
-    return @[ @"com.googlecode.munki.admin",
-              @"com.googlecode.munki.app",
-              @"com.googlecode.munki.app_usage",
-              @"com.googlecode.munki.core",
-              @"com.googlecode.munki.launchd" ];
-}
-
-- (NSString *)munkiVersionFromReceiptsInDirectory:(NSString *)dir
-{
-    NSString *highestVersion = nil;
-    for (NSString *identifier in [self munkiPackageIdentifiers]) {
-        NSString *receiptPath = [[dir stringByAppendingPathComponent:identifier] stringByAppendingPathExtension:@"plist"];
-        NSDictionary *receiptDict = [NSDictionary dictionaryWithContentsOfFile:receiptPath];
-        NSString *version = receiptDict[@"PackageVersion"];
-        if (version && (!highestVersion || [version version_isGreaterThan:highestVersion])) {
-            highestVersion = version;
-        }
-    }
-    return highestVersion;
-}
-
 - (void)writeReceiptPlistAtPath:(NSString *)path version:(NSString *)version
 {
     NSDictionary *receipt = @{
@@ -292,15 +290,10 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
     // --version reported 6.6.0.4686, because the code/client rev count was lower
     // than the code/apps rev count used for the metapackage build number.
     // Reading receipts should yield the correct metapackage version.
-    NSString *tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:
-                        [[NSUUID UUID] UUIDString]];
-    [[NSFileManager defaultManager] createDirectoryAtPath:tmpDir
-                              withIntermediateDirectories:YES
-                                               attributes:nil
-                                                    error:nil];
+    NSString *tmpDir = [self createTempDirectory];
 
     NSString *metapackageVersion = @"6.6.0.4690";
-    for (NSString *identifier in [self munkiPackageIdentifiers]) {
+    for (NSString *identifier in [LGMunkiIntegration packageIdentifiers]) {
         NSString *path = [[tmpDir stringByAppendingPathComponent:identifier]
                           stringByAppendingPathExtension:@"plist"];
         if ([identifier isEqualToString:@"com.googlecode.munki.launchd"]) {
@@ -310,7 +303,7 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
         }
     }
 
-    NSString *detectedVersion = [self munkiVersionFromReceiptsInDirectory:tmpDir];
+    NSString *detectedVersion = [LGMunkiIntegration installedVersionFromReceiptsInDirectory:tmpDir];
     XCTAssertEqualObjects(detectedVersion, metapackageVersion,
         @"Receipt-based detection should return the metapackage version");
 
@@ -321,20 +314,13 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
         @"munkiimport --version (4686) is less than the metapackage (4690)");
     XCTAssertFalse([metapackageVersion version_isGreaterThan:detectedVersion],
         @"Receipt-based version should not falsely trigger an update");
-
-    [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
 }
 
 - (void)testMunkiReceiptVersionWithDivergentBuildNumbers
 {
     // Simulate real-world receipts where sub-packages have different build numbers.
     // The launchd package often lags behind because its content changes less frequently.
-    NSString *tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:
-                        [[NSUUID UUID] UUIDString]];
-    [[NSFileManager defaultManager] createDirectoryAtPath:tmpDir
-                              withIntermediateDirectories:YES
-                                               attributes:nil
-                                                    error:nil];
+    NSString *tmpDir = [self createTempDirectory];
 
     NSDictionary *receiptVersions = @{
         @"com.googlecode.munki.admin"     : @"7.1.2.5700",
@@ -349,21 +335,23 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
         [self writeReceiptPlistAtPath:path version:receiptVersions[identifier]];
     }
 
-    NSString *detectedVersion = [self munkiVersionFromReceiptsInDirectory:tmpDir];
+    NSString *detectedVersion = [LGMunkiIntegration installedVersionFromReceiptsInDirectory:tmpDir];
     XCTAssertEqualObjects(detectedVersion, @"7.1.2.5700",
         @"Should return the highest version across all receipts");
-
-    [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
 }
 
-- (void)testMunkiReceiptVersionExcludesPythonlibs
+- (void)testMunkiPackageIdentifiers
 {
-    // The pythonlibs receipt can have a completely different version (e.g. 6.7.0.5293
-    // when the rest of Munki is 7.1.2.5700). Verify it is excluded from the
-    // identifier list so it cannot poison the version detection.
-    NSArray *identifiers = [self munkiPackageIdentifiers];
+    // Guard against drift in the production identifier list. The pythonlibs
+    // receipt can have a completely different version (e.g. 6.7.0.5293 when
+    // the rest of Munki is 7.1.2.5700) and must not be in the list, or it
+    // would poison the version detection. app_usage must be in the list
+    // because it's part of the metapackage.
+    NSArray *identifiers = [LGMunkiIntegration packageIdentifiers];
     XCTAssertFalse([identifiers containsObject:@"com.googlecode.munki.pythonlibs"],
         @"pythonlibs must not be in packageIdentifiers");
+    XCTAssertTrue([identifiers containsObject:@"com.googlecode.munki.app_usage"],
+        @"app_usage must be in packageIdentifiers");
 }
 
 - (void)testMunkiReceiptVersionNoFalseUpdateForV660
@@ -387,18 +375,11 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
 - (void)testMunkiReceiptVersionMissingReceipts
 {
     // When no receipts exist (Munki not installed), the method should return nil.
-    NSString *tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:
-                        [[NSUUID UUID] UUIDString]];
-    [[NSFileManager defaultManager] createDirectoryAtPath:tmpDir
-                              withIntermediateDirectories:YES
-                                               attributes:nil
-                                                    error:nil];
+    NSString *tmpDir = [self createTempDirectory];
 
-    NSString *detectedVersion = [self munkiVersionFromReceiptsInDirectory:tmpDir];
+    NSString *detectedVersion = [LGMunkiIntegration installedVersionFromReceiptsInDirectory:tmpDir];
     XCTAssertNil(detectedVersion,
         @"Should return nil when no receipt plists exist");
-
-    [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
 }
 
 - (void)testLoader


### PR DESCRIPTION
AutoPkgr currently detects the installed Munki version by running `munkiimport --version`, but that command can report a lower build number than the metapackage it shipped in. Munki 6.6.0, for instance, shipped as `munkitools-6.6.0.4690.pkg` while `munkiimport --version` reported `6.6.0.4686`. The result was AutoPkgr repeatedly offering an "update" for a version that was already installed. (https://github.com/lindegroup/autopkgr/issues/493, https://github.com/lindegroup/autopkgr/issues/595, https://github.com/lindegroup/autopkgr/issues/614, https://github.com/lindegroup/autopkgr/issues/659, and https://github.com/lindegroup/autopkgr/issues/694)

This switches version detection to read the macOS package receipts in `/private/var/db/receipts/` instead, taking the highest version across Munki's sub-packages. That mirrors how Munki's own build script settles on the metapackage version, so what AutoPkgr reports now lines up with what's actually installed. Along the way the sub-package identifier list got a refresh — adding `app_usage`, dropping the obsolete `munkiwebadmin-scripts`, and leaving out python-related receipts, which Munki is moving away from.

Also includes test coverage for the receipt logic.

I would have loved to ship this 10 years ago. Now I have access to AI coding tools that make it feasible for me.