### PR TITLE
Add support for parsing YAML recipes

### DIFF
--- a/AutoPkgr/Models/AutoPkg Task/LGAutoPkgRecipe.m
+++ b/AutoPkgr/Models/AutoPkg Task/LGAutoPkgRecipe.m
@@ -20,12 +20,14 @@
 #import "LGAutoPkgRecipe.h"
 #import "LGAutoPkgRecipeListManager.h"
 #import "LGAutoPkgTask.h"
+#import "LGLogger.h"
 
 #import <glob.h>
 
 // MakeCatalogs recipe identifier string.
 static NSString *const kLGMakeCatalogsRecipeName = @"MakeCatalogs.munki";
 static NSString *const kLGMakeCatalogsIdentifier = @"com.github.autopkg.munki.makecatalogs";
+static NSString *const kLGAutoPkgPythonPath = @"/usr/local/autopkg/python";
 
 // Dispatch queue for enabling / disabling recipe.
 static dispatch_queue_t autopkgr_recipe_write_queue()
@@ -40,6 +42,61 @@ static dispatch_queue_t autopkgr_recipe_write_queue()
 }
 
 static NSMutableDictionary *_identifierURLStore = nil;
+static NSMutableDictionary *_recipeDictionaryCache = nil;
+
+static NSString *LGRecipeNameFromURL(NSURL *recipeURL)
+{
+    NSString *fileName = recipeURL.lastPathComponent;
+    NSString *lowercaseFileName = fileName.lowercaseString;
+    for (NSString *extension in @[ @".recipe.yaml", @".recipe.plist", @".recipe" ]) {
+        if ([lowercaseFileName hasSuffix:extension]) {
+            return [fileName substringToIndex:fileName.length - extension.length];
+        }
+    }
+    return [fileName stringByDeletingPathExtension];
+}
+
+static NSString *LGRecipeDictionaryCacheKey(NSURL *recipeURL)
+{
+    NSString *path = recipeURL.path;
+    NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:nil];
+    NSDate *modificationDate = attributes[NSFileModificationDate];
+    NSNumber *fileSize = attributes[NSFileSize];
+
+    if (!path.length || !modificationDate || !fileSize) {
+        return nil;
+    }
+
+    return [NSString stringWithFormat:@"%@:%@:%@", path, @([modificationDate timeIntervalSinceReferenceDate]), fileSize];
+}
+
+static BOOL LGRecipeURLIsYAMLRecipe(NSURL *recipeURL)
+{
+    return [recipeURL.lastPathComponent.lowercaseString hasSuffix:@".recipe.yaml"];
+}
+
+static NSArray *LGYAMLRecipeURLsRecursivelyAtPath(NSString *path)
+{
+    NSMutableArray *recipeURLs = [[NSMutableArray alloc] init];
+
+    if (path && (access(path.UTF8String, F_OK) == 0)) {
+        NSString *matches = [NSString stringWithFormat:@"{%@/{*.recipe.yaml,*/*.recipe.yaml}}", path];
+
+        glob_t results;
+        glob(matches.UTF8String, GLOB_BRACE | GLOB_NOSORT, NULL, &results);
+        for (int i = 0; i < results.gl_matchc; i++) {
+            NSString *globPath = [NSString stringWithUTF8String:results.gl_pathv[i]];
+            NSURL *fileURL = [NSURL fileURLWithPath:globPath isDirectory:NO];
+
+            if (fileURL) {
+                [recipeURLs addObject:fileURL];
+            }
+        }
+        globfree(&results);
+    }
+
+    return [recipeURLs copy];
+}
 
 #pragma mark - Recipes
 //////////////////////////////////////////////////////////////////////////
@@ -58,6 +115,199 @@ static NSMutableDictionary *_identifierURLStore = nil;
 
 @synthesize Description = _Description, MinimumVersion = _MinimumVersion;
 
++ (NSDictionary *)dictionariesFromYAMLRecipeURLs:(NSArray *)recipeURLs
+{
+    NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];
+    NSMutableDictionary *recipeDictionariesByPath = [[NSMutableDictionary alloc] init];
+    NSMutableArray *pathsToParse = [[NSMutableArray alloc] init];
+    NSMutableDictionary *cacheKeysByPath = [[NSMutableDictionary alloc] init];
+
+    for (NSURL *recipeURL in recipeURLs) {
+        if (!LGRecipeURLIsYAMLRecipe(recipeURL) || !recipeURL.path.length) {
+            continue;
+        }
+
+        NSString *cacheKey = LGRecipeDictionaryCacheKey(recipeURL);
+        if (cacheKey) {
+            @synchronized(self) {
+                NSDictionary *cachedRecipe = _recipeDictionaryCache[cacheKey];
+                if (cachedRecipe) {
+                    recipeDictionariesByPath[recipeURL.path] = cachedRecipe;
+                    continue;
+                }
+            }
+            cacheKeysByPath[recipeURL.path] = cacheKey;
+        }
+
+        [pathsToParse addObject:recipeURL.path];
+    }
+
+    NSUInteger cachedRecipeCount = recipeDictionariesByPath.count;
+    if (!pathsToParse.count || ![[NSFileManager defaultManager] isExecutableFileAtPath:kLGAutoPkgPythonPath]) {
+        LGLaunchProfileLog(@"YAML recipe batch skipped parse requested=%lu cached=%lu elapsed=%.3fs",
+                           (unsigned long)recipeURLs.count,
+                           (unsigned long)cachedRecipeCount,
+                           [NSDate timeIntervalSinceReferenceDate] - startTime);
+        return [recipeDictionariesByPath copy];
+    }
+
+    LGLaunchProfileLog(@"YAML recipe batch parse start requested=%lu toParse=%lu cached=%lu",
+                       (unsigned long)recipeURLs.count,
+                       (unsigned long)pathsToParse.count,
+                       (unsigned long)cachedRecipeCount);
+
+    NSData *inputData = [NSPropertyListSerialization dataWithPropertyList:pathsToParse
+                                                                    format:NSPropertyListXMLFormat_v1_0
+                                                                   options:0
+                                                                     error:nil];
+    if (!inputData) {
+        LGLaunchProfileLog(@"YAML recipe batch parse aborted; failed to serialize path list elapsed=%.3fs",
+                           [NSDate timeIntervalSinceReferenceDate] - startTime);
+        return [recipeDictionariesByPath copy];
+    }
+
+    NSString *script = @"import plistlib\n"
+                       @"import sys\n"
+                       @"import yaml\n"
+                       @"try:\n"
+                       @"    sys.path.insert(0, \"/Library/AutoPkg\")\n"
+                       @"    from autopkglib.autopkgyaml import AutoPkgYAMLLoader\n"
+                       @"except Exception:\n"
+                       @"    class AutoPkgYAMLLoader(yaml.SafeLoader):\n"
+                       @"        pass\n"
+                       @"    AutoPkgYAMLLoader.yaml_implicit_resolvers = AutoPkgYAMLLoader.yaml_implicit_resolvers.copy()\n"
+                       @"    for first_letter, mappings in list(AutoPkgYAMLLoader.yaml_implicit_resolvers.items()):\n"
+                       @"        AutoPkgYAMLLoader.yaml_implicit_resolvers[first_letter] = [\n"
+                       @"            (tag, regexp) for tag, regexp in mappings\n"
+                       @"            if tag != \"tag:yaml.org,2002:float\"\n"
+                       @"        ]\n"
+                       @"def plist_serializer(obj):\n"
+                       @"    if isinstance(obj, dict):\n"
+                       @"        for key, value in obj.items():\n"
+                       @"            obj[key] = \"\" if value is None else plist_serializer(value)\n"
+                       @"    elif isinstance(obj, list):\n"
+                       @"        for index in range(len(obj)):\n"
+                       @"            obj[index] = \"\" if obj[index] is None else plist_serializer(obj[index])\n"
+                       @"    return obj\n"
+                       @"recipes = {}\n"
+                       @"for path in plistlib.loads(sys.stdin.buffer.read()):\n"
+                       @"    try:\n"
+                       @"        with open(path, \"rb\") as recipe_file:\n"
+                       @"            recipe = yaml.load(recipe_file, Loader=AutoPkgYAMLLoader)\n"
+                       @"        if not isinstance(recipe, dict):\n"
+                       @"            continue\n"
+                       @"        recipe = plist_serializer(recipe)\n"
+                       @"        plistlib.dumps(recipe, fmt=plistlib.FMT_XML)\n"
+                       @"        recipes[path] = recipe\n"
+                       @"    except Exception:\n"
+                       @"        pass\n"
+                       @"sys.stdout.buffer.write(plistlib.dumps(recipes, fmt=plistlib.FMT_XML))\n";
+
+    NSTask *task = [[NSTask alloc] init];
+    task.launchPath = kLGAutoPkgPythonPath;
+    task.arguments = @[ @"-c", script ];
+    task.standardInput = [NSPipe pipe];
+    task.standardOutput = [NSPipe pipe];
+    task.standardError = [NSFileHandle fileHandleWithNullDevice];
+
+    NSData *data = nil;
+    @try {
+        [task launch];
+        [[task.standardInput fileHandleForWriting] writeData:inputData];
+        [[task.standardInput fileHandleForWriting] closeFile];
+        data = [[task.standardOutput fileHandleForReading] readDataToEndOfFile];
+        [task waitUntilExit];
+    }
+    @catch (NSException *exception) {
+        if (task.isRunning) {
+            [task terminate];
+        }
+        LGLaunchProfileLog(@"YAML recipe batch parse exception %@ elapsed=%.3fs",
+                           exception.name,
+                           [NSDate timeIntervalSinceReferenceDate] - startTime);
+        return [recipeDictionariesByPath copy];
+    }
+
+    if (task.terminationStatus != 0 || data.length == 0) {
+        LGLaunchProfileLog(@"YAML recipe batch parse failed status=%d outputBytes=%lu elapsed=%.3fs",
+                           task.terminationStatus,
+                           (unsigned long)data.length,
+                           [NSDate timeIntervalSinceReferenceDate] - startTime);
+        return [recipeDictionariesByPath copy];
+    }
+
+    id recipes = [NSPropertyListSerialization propertyListWithData:data
+                                                           options:NSPropertyListImmutable
+                                                            format:nil
+                                                             error:nil];
+    if (![recipes isKindOfClass:[NSDictionary class]]) {
+        LGLaunchProfileLog(@"YAML recipe batch parse returned non-dictionary elapsed=%.3fs",
+                           [NSDate timeIntervalSinceReferenceDate] - startTime);
+        return [recipeDictionariesByPath copy];
+    }
+
+    @synchronized(self) {
+        if (!_recipeDictionaryCache) {
+            _recipeDictionaryCache = [[NSMutableDictionary alloc] init];
+        }
+        [recipes enumerateKeysAndObjectsUsingBlock:^(id path, id recipe, BOOL *stop) {
+            if (![recipe isKindOfClass:[NSDictionary class]]) {
+                return;
+            }
+
+            NSString *cacheKey = cacheKeysByPath[path];
+            if (cacheKey) {
+                _recipeDictionaryCache[cacheKey] = recipe;
+            }
+            recipeDictionariesByPath[path] = recipe;
+        }];
+    }
+
+    LGLaunchProfileLog(@"YAML recipe batch parse complete requested=%lu parsed=%lu cached=%lu elapsed=%.3fs",
+                       (unsigned long)recipeURLs.count,
+                       (unsigned long)[recipes count],
+                       (unsigned long)cachedRecipeCount,
+                       [NSDate timeIntervalSinceReferenceDate] - startTime);
+
+    return [recipeDictionariesByPath copy];
+}
+
++ (void)cacheDictionariesFromYAMLRecipesAtPaths:(NSArray *)paths
+{
+    NSMutableArray *recipeURLs = [[NSMutableArray alloc] init];
+
+    for (NSString *path in paths) {
+        [recipeURLs addObjectsFromArray:LGYAMLRecipeURLsRecursivelyAtPath(path)];
+    }
+
+    [[self class] dictionariesFromYAMLRecipeURLs:recipeURLs];
+}
+
++ (NSDictionary *)dictionaryFromRecipeURL:(NSURL *)recipeURL
+{
+    if (!LGRecipeURLIsYAMLRecipe(recipeURL)) {
+        // Standalone .yaml files aren't recipes; anything else is read as a plist.
+        NSString *lowercaseName = recipeURL.lastPathComponent.lowercaseString;
+        if ([lowercaseName hasSuffix:@".yaml"]) {
+            return nil;
+        }
+        return [NSDictionary dictionaryWithContentsOfURL:recipeURL];
+    }
+
+    NSString *cacheKey = LGRecipeDictionaryCacheKey(recipeURL);
+    if (cacheKey) {
+        @synchronized(self) {
+            NSDictionary *cachedRecipe = _recipeDictionaryCache[cacheKey];
+            if (cachedRecipe) {
+                return cachedRecipe;
+            }
+        }
+    }
+
+    NSString *path = recipeURL.path;
+    return path.length ? [[self class] dictionariesFromYAMLRecipeURLs:@[ recipeURL ]][path] : nil;
+}
+
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"Name: %@ Identifier: %@ Parent: %@", _Name, _Identifier, self.ParentRecipe];
@@ -66,15 +316,15 @@ static NSMutableDictionary *_identifierURLStore = nil;
 - (instancetype)initWithRecipeFile:(NSURL *)recipeFile isOverride:(BOOL)isOverride
 {
     // Don't initialize anything if we can't determine a recipe identifier.
-    NSDictionary *reciptPlist = [NSDictionary dictionaryWithContentsOfURL:recipeFile];
+    NSDictionary *reciptPlist = [[self class] dictionaryFromRecipeURL:recipeFile];
     NSString *identifier = reciptPlist[kLGAutoPkgRecipeIdentifierKey] ?: reciptPlist[@"Input"][@"IDENTIFIER"];
 
-    if (identifier && (self = [super init])) {
+    if (identifier.length && (self = [super init])) {
         _recipePlist = reciptPlist;
         _Identifier = identifier;
 
         _recipeFileURL = recipeFile;
-        _Name = [[recipeFile lastPathComponent] stringByDeletingPathExtension];
+        _Name = LGRecipeNameFromURL(recipeFile);
 
         _FilePath = recipeFile.path;
         _isOverride = isOverride;
@@ -98,7 +348,8 @@ static NSMutableDictionary *_identifierURLStore = nil;
 
 - (NSString *)ParentRecipe
 {
-    return _recipePlist[kLGAutoPkgRecipeParentKey];
+    NSString *parentRecipe = _recipePlist[kLGAutoPkgRecipeParentKey];
+    return parentRecipe.length ? parentRecipe : nil;
 }
 
 - (NSArray *)ParentRecipes
@@ -114,10 +365,13 @@ static NSMutableDictionary *_identifierURLStore = nil;
         while (true) {
             NSURL *parentRecipeURL = [_identifierURLStore objectForKey:parentRecipeID];
             if (parentRecipeURL) {
-                NSDictionary *recipePlist = [NSDictionary dictionaryWithContentsOfURL:parentRecipeURL];
+                NSDictionary *recipePlist = [[self class] dictionaryFromRecipeURL:parentRecipeURL];
                 parentRecipeID = recipePlist[kLGAutoPkgRecipeParentKey];
-                if (parentRecipeID) {
+                if (parentRecipeID.length) {
                     [parents addObject:parentRecipeID];
+                }
+                else {
+                    break;
                 }
             }
             else {
@@ -276,7 +530,7 @@ static NSMutableDictionary *_identifierURLStore = nil;
 {
     NSURL *recipeURL = [_identifierURLStore objectForKey:identifier];
     if (recipeURL) {
-        return [NSDictionary dictionaryWithContentsOfURL:recipeURL];
+        return [[self class] dictionaryFromRecipeURL:recipeURL];
     }
     return nil;
 }
@@ -294,13 +548,31 @@ static NSMutableDictionary *_identifierURLStore = nil;
 
 + (NSArray *)allRecipesFilteringOverlaps:(BOOL)filterOverlaps
 {
+    NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];
+    LGLaunchProfileLog(@"allRecipes scan start filterOverlaps=%@", filterOverlaps ? @"YES" : @"NO");
+
     _identifierURLStore = [[NSMutableDictionary alloc] init];
+    @synchronized(self) {
+        _recipeDictionaryCache = [[NSMutableDictionary alloc] init];
+    }
     LGDefaults *defaults = [LGDefaults standardUserDefaults];
 
     NSMutableArray *allRecipes = [[NSMutableArray alloc] init];
     NSSet *activeRecipes = [self activeRecipes];
 
     NSArray *searchDirs = defaults.autoPkgRecipeSearchDirs;
+    NSMutableArray *recipeSearchPaths = [[NSMutableArray alloc] init];
+    for (NSString *searchDir in searchDirs) {
+        if (![searchDir isEqualToString:@"."]) {
+            [recipeSearchPaths addObject:searchDir.stringByExpandingTildeInPath];
+        }
+    }
+
+    NSString *recipeOverridePath = defaults.autoPkgRecipeOverridesDir ?: @"~/Library/AutoPkg/RecipeOverrides".stringByExpandingTildeInPath;
+    [recipeSearchPaths addObject:recipeOverridePath];
+    [self cacheDictionariesFromYAMLRecipesAtPaths:recipeSearchPaths];
+    LGLaunchProfileLog(@"allRecipes YAML preload complete paths=%lu", (unsigned long)recipeSearchPaths.count);
+
     for (NSString *searchDir in searchDirs) {
         if (![searchDir isEqualToString:@"."]) {
             NSArray *recipeArray = [self findRecipesRecursivelyAtPath:searchDir.stringByExpandingTildeInPath isOverride:NO activeRecipes:activeRecipes];
@@ -309,10 +581,10 @@ static NSMutableDictionary *_identifierURLStore = nil;
             }
         }
     }
-
-    NSString *recipeOverridePath = defaults.autoPkgRecipeOverridesDir ?: @"~/Library/AutoPkg/RecipeOverrides".stringByExpandingTildeInPath;
+    LGLaunchProfileLog(@"allRecipes repo scan complete count=%lu", (unsigned long)allRecipes.count);
 
     NSArray *overrideArray = [self findRecipesRecursivelyAtPath:recipeOverridePath isOverride:YES activeRecipes:activeRecipes];
+    LGLaunchProfileLog(@"allRecipes override scan complete count=%lu", (unsigned long)overrideArray.count);
     NSMutableArray *validOverrides = [[NSMutableArray alloc] init];
 
     for (LGAutoPkgRecipe * override in overrideArray) {
@@ -346,6 +618,9 @@ static NSMutableDictionary *_identifierURLStore = nil;
                                                                ascending:YES];
 
     [allRecipes sortUsingDescriptors:@[ descriptor ]];
+    LGLaunchProfileLog(@"allRecipes scan complete count=%lu elapsed=%.3fs",
+                       (unsigned long)allRecipes.count,
+                       [NSDate timeIntervalSinceReferenceDate] - startTime);
 
     validOverrides = nil;
 
@@ -355,12 +630,27 @@ static NSMutableDictionary *_identifierURLStore = nil;
 + (NSArray *)findRecipesRecursivelyAtPath:(NSString *)path isOverride:(BOOL)isOverride activeRecipes:(NSSet *)activeRecipes
 {
     NSMutableArray *recipes = [[NSMutableArray alloc] init];
+    if (!_identifierURLStore) {
+        _identifierURLStore = [[NSMutableDictionary alloc] init];
+    }
 
     if (path && (access(path.UTF8String, F_OK) == 0)) {
-        NSString *matches = [NSString stringWithFormat:@"{%@/{*.recipe,*/*.recipe,*.yaml,*/*.yaml,*.plist,*/*.plist}}", path];
+        NSString *matches = [NSString stringWithFormat:@"{%@/{*.recipe,*/*.recipe,*.recipe.yaml,*/*.recipe.yaml,*.plist,*/*.plist}}", path];
 
         glob_t results;
         glob(matches.UTF8String, GLOB_BRACE | GLOB_NOSORT, NULL, &results);
+        NSMutableArray *yamlRecipeURLs = [[NSMutableArray alloc] init];
+        for (int i = 0; i < results.gl_matchc; i++) {
+            NSString *globPath = [NSString stringWithUTF8String:results.gl_pathv[i]];
+            NSURL *fileURL = [NSURL fileURLWithPath:globPath isDirectory:NO];
+
+            if (LGRecipeURLIsYAMLRecipe(fileURL)) {
+                [yamlRecipeURLs addObject:fileURL];
+            }
+        }
+
+        [[self class] dictionariesFromYAMLRecipeURLs:yamlRecipeURLs];
+
         for (int i = 0; i < results.gl_matchc; i++) {
             NSString *globPath = [NSString stringWithUTF8String:results.gl_pathv[i]];
             NSURL *fileURL = [NSURL fileURLWithPath:globPath isDirectory:NO];

--- a/AutoPkgr/Models/AutoPkg Task/LGAutoPkgRecipe.m
+++ b/AutoPkgr/Models/AutoPkg Task/LGAutoPkgRecipe.m
@@ -342,12 +342,29 @@ static NSArray *LGYAMLRecipeURLsRecursivelyAtPath(NSString *path)
 
 - (NSString *)Description
 {
-    return _recipePlist[NSStringFromSelector(_cmd)] ?: [self objectForKey:NSStringFromSelector(_cmd) ofIdentifier:self.ParentRecipe];
+    return [self stringValueForKey:NSStringFromSelector(_cmd)];
 }
 
 - (NSString *)MinimumVersion
 {
-    return _recipePlist[NSStringFromSelector(_cmd)] ?: [self objectForKey:NSStringFromSelector(_cmd) ofIdentifier:self.ParentRecipe];
+    return [self stringValueForKey:NSStringFromSelector(_cmd)];
+}
+
+// These accessors are declared to return NSString * and feed
+// NSTextField.safe_stringValue (which sends -length), but YAML (or a malformed
+// plist) can yield a non-string scalar — e.g. `MinimumVersion: 3` parses as an
+// NSNumber. Coerce numbers to strings and reject other non-string types so we
+// never hand back something that crashes on -length.
+- (NSString *)stringValueForKey:(NSString *)key
+{
+    id value = _recipePlist[key] ?: [self objectForKey:key ofIdentifier:self.ParentRecipe];
+    if ([value isKindOfClass:[NSString class]]) {
+        return value;
+    }
+    if ([value isKindOfClass:[NSNumber class]]) {
+        return [value stringValue];
+    }
+    return nil;
 }
 
 - (NSString *)ParentRecipe

--- a/AutoPkgr/Models/AutoPkg Task/LGAutoPkgRecipe.m
+++ b/AutoPkgr/Models/AutoPkg Task/LGAutoPkgRecipe.m
@@ -317,7 +317,11 @@ static NSArray *LGYAMLRecipeURLsRecursivelyAtPath(NSString *path)
 {
     // Don't initialize anything if we can't determine a recipe identifier.
     NSDictionary *reciptPlist = [[self class] dictionaryFromRecipeURL:recipeFile];
-    NSString *identifier = reciptPlist[kLGAutoPkgRecipeIdentifierKey] ?: reciptPlist[@"Input"][@"IDENTIFIER"];
+    id identifierValue = reciptPlist[kLGAutoPkgRecipeIdentifierKey] ?: reciptPlist[@"Input"][@"IDENTIFIER"];
+
+    // YAML (or a malformed plist) can produce a non-string identifier (e.g. a
+    // number), so reject anything that isn't a string to avoid crashing on -length.
+    NSString *identifier = [identifierValue isKindOfClass:[NSString class]] ? identifierValue : nil;
 
     if (identifier.length && (self = [super init])) {
         _recipePlist = reciptPlist;
@@ -348,8 +352,13 @@ static NSArray *LGYAMLRecipeURLsRecursivelyAtPath(NSString *path)
 
 - (NSString *)ParentRecipe
 {
-    NSString *parentRecipe = _recipePlist[kLGAutoPkgRecipeParentKey];
-    return parentRecipe.length ? parentRecipe : nil;
+    // YAML (or a malformed plist) can produce a non-string ParentRecipe value;
+    // only treat an actual non-empty string as a valid parent identifier.
+    id parentRecipe = _recipePlist[kLGAutoPkgRecipeParentKey];
+    if ([parentRecipe isKindOfClass:[NSString class]] && [parentRecipe length]) {
+        return parentRecipe;
+    }
+    return nil;
 }
 
 - (NSArray *)ParentRecipes
@@ -366,7 +375,10 @@ static NSArray *LGYAMLRecipeURLsRecursivelyAtPath(NSString *path)
             NSURL *parentRecipeURL = [_identifierURLStore objectForKey:parentRecipeID];
             if (parentRecipeURL) {
                 NSDictionary *recipePlist = [[self class] dictionaryFromRecipeURL:parentRecipeURL];
-                parentRecipeID = recipePlist[kLGAutoPkgRecipeParentKey];
+                id parentRecipeValue = recipePlist[kLGAutoPkgRecipeParentKey];
+                // A non-string parent identifier (possible with YAML or a
+                // malformed plist) ends the chain rather than crashing on -length.
+                parentRecipeID = [parentRecipeValue isKindOfClass:[NSString class]] ? parentRecipeValue : nil;
                 if (parentRecipeID.length) {
                     [parents addObject:parentRecipeID];
                 }
@@ -568,7 +580,10 @@ static NSArray *LGYAMLRecipeURLsRecursivelyAtPath(NSString *path)
         }
     }
 
-    NSString *recipeOverridePath = defaults.autoPkgRecipeOverridesDir ?: @"~/Library/AutoPkg/RecipeOverrides".stringByExpandingTildeInPath;
+    // Expand the whole expression: the overrides dir read from AutoPkg's prefs
+    // may contain a "~", and it's later used with access()/glob() (which don't
+    // expand tildes) during the YAML preload below.
+    NSString *recipeOverridePath = (defaults.autoPkgRecipeOverridesDir ?: @"~/Library/AutoPkg/RecipeOverrides").stringByExpandingTildeInPath;
     [recipeSearchPaths addObject:recipeOverridePath];
     [self cacheDictionariesFromYAMLRecipesAtPaths:recipeSearchPaths];
     LGLaunchProfileLog(@"allRecipes YAML preload complete paths=%lu", (unsigned long)recipeSearchPaths.count);

--- a/AutoPkgr/Supporting Files/main.m
+++ b/AutoPkgr/Supporting Files/main.m
@@ -27,12 +27,15 @@
 
 int main(int argc, const char *argv[])
 {
+    LGLaunchProfileStart();
+
     NSUserDefaults *args = [NSUserDefaults standardUserDefaults];
 
     NSString *reportItemKey = NSStringFromSelector(@selector(reportedItemFlags));
     [args registerDefaults:@{ reportItemKey : @(kLGReportItemsAll) }];
 
     if ([args boolForKey:@"runInBackground"]) {
+        LGLaunchProfileLog(@"background run requested; skipping window launch profile");
         NSLog(@"Running AutoPkgr in background...");
 
         NSURLCache *sharedCache = [[NSURLCache alloc] initWithMemoryCapacity:0
@@ -84,6 +87,7 @@ int main(int argc, const char *argv[])
         return 0;
     }
     else {
+        LGLaunchProfileLog(@"entering NSApplicationMain");
         return NSApplicationMain(argc, argv);
     }
 }

--- a/AutoPkgr/Utility/LGLogger.h
+++ b/AutoPkgr/Utility/LGLogger.h
@@ -27,3 +27,6 @@ NSString *quick_pathJoin(NSArray *components);
 //
 void DLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
 void DevLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+
+void LGLaunchProfileStart(void);
+void LGLaunchProfileLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);

--- a/AutoPkgr/Utility/LGLogger.m
+++ b/AutoPkgr/Utility/LGLogger.m
@@ -20,6 +20,13 @@
 
 #include "LGLogger.h"
 
+static NSTimeInterval _launchProfileStartTime = 0;
+
+static BOOL LGDebugLoggingEnabled(void)
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"debug"];
+}
+
 NSString *quick_formatString(NSString *format, ...)
 {
     NSString *string = nil;
@@ -52,7 +59,7 @@ NSString *quick_pathJoin(NSArray *components)
 // Debug Logging Method
 void DLog(NSString *format, ...)
 {
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"debug"]) {
+    if (LGDebugLoggingEnabled()) {
         if (format) {
             va_list args;
             va_start(args, format);
@@ -72,4 +79,27 @@ void DevLog(NSString *format, ...)
         va_end(args);
     }
 #endif
+}
+
+void LGLaunchProfileStart(void)
+{
+    _launchProfileStartTime = [NSDate timeIntervalSinceReferenceDate];
+    DLog(@"Launch profile: +0.000s process entry");
+}
+
+void LGLaunchProfileLog(NSString *format, ...)
+{
+    if (!_launchProfileStartTime) {
+        _launchProfileStartTime = [NSDate timeIntervalSinceReferenceDate];
+    }
+
+    if (format && LGDebugLoggingEnabled()) {
+        va_list args;
+        va_start(args, format);
+        NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+        va_end(args);
+
+        NSTimeInterval elapsed = [NSDate timeIntervalSinceReferenceDate] - _launchProfileStartTime;
+        DLog(@"Launch profile: +%.3fs %@", elapsed, message);
+    }
 }

--- a/AutoPkgr/Views-Controllers-XIB/LGAppDelegate.m
+++ b/AutoPkgr/Views-Controllers-XIB/LGAppDelegate.m
@@ -50,6 +50,7 @@
 #pragma mark-- Launching --
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
 {
+    LGLaunchProfileLog(@"applicationWillFinishLaunching");
 
     // Set up activation policy. By default set as menubar only.
     [[LGDefaults standardUserDefaults] registerDefaults:@{ kLGApplicationDisplayStyle : @(kLGDisplayStyleShowMenu | kLGDisplayStyleShowDock) }];
@@ -61,11 +62,13 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
+    LGLaunchProfileLog(@"applicationDidFinishLaunching start");
     NSLog(@"Welcome to AutoPkgr!");
     DLog(@"Verbose logging is active. To deactivate, click the AutoPkgr menu icon and uncheck Verbose Logs.");
 
     // Set up the status item.
     [self setupStatusItem];
+    LGLaunchProfileLog(@"status item setup complete");
 
     // Check if we're authorized to install helper tool. If not just quit.
     NSError *error;
@@ -78,6 +81,7 @@
         [NSApp presentError:[LGError errorWithCode:kLGErrorInstallingPrivilegedHelperTool]];
         [[NSApplication sharedApplication] terminate:self];
     }
+    LGLaunchProfileLog(@"helper authorization check complete");
 
     // Register to get background progress updates.
     LGAutoPkgrHelperConnection *backgroundMonitor = [[LGAutoPkgrHelperConnection alloc] initWithProgressDelegate:self];
@@ -100,12 +104,15 @@
 
         [[NSApplication sharedApplication] terminate:self];
     }
+    LGLaunchProfileLog(@"recipe identifier migration check complete");
 
     // Set up User Notification Delegate
     _notificationDelegate = [[LGUserNotificationsDelegate alloc] initAsDefaultCenterDelegate];
+    LGLaunchProfileLog(@"notification delegate setup complete");
 
     // Calling stopProgress: here is an easy way to get the menu reset to its default configuration.
     [self stopProgress:nil];
+    LGLaunchProfileLog(@"initial progress reset queued");
 
     [self showConfigurationWindow:self];
 }
@@ -242,21 +249,30 @@
 
 - (void)showConfigurationWindow:(id)sender
 {
+    LGLaunchProfileLog(@"showConfigurationWindow requested");
+
     // If the application was launched at login, defer loading the configuration window once.
     if ([[[NSProcessInfo processInfo] arguments] containsObject:kLGLaunchedAtLogin]) {
         if (!_configurationWindowDeferred) {
             _configurationWindowDeferred = YES;
+            LGLaunchProfileLog(@"configuration window load deferred for login launch");
             return;
         }
     }
 
     if (!_configurationWindowController) {
+        LGLaunchProfileLog(@"configuration window controller allocation start");
         _configurationWindowController = [[LGConfigurationWindowController alloc] initWithProgressDelegate:self];
+        LGLaunchProfileLog(@"configuration window controller allocation complete");
         _configurationWindowController.scheduleView.scheduleMenuItem = _autoCheckForUpdatesMenuItem;
     }
 
     [NSApp activateIgnoringOtherApps:YES];
     [self->_configurationWindowController.window makeKeyAndOrderFront:nil];
+    LGLaunchProfileLog(@"configuration window ordered front visible=%@", self->_configurationWindowController.window.isVisible ? @"YES" : @"NO");
+    dispatch_async(dispatch_get_main_queue(), ^{
+        LGLaunchProfileLog(@"configuration window next main-loop tick visible=%@", self->_configurationWindowController.window.isVisible ? @"YES" : @"NO");
+    });
     DLog(@"Activated AutoPkgr configuration window.");
 }
 

--- a/AutoPkgr/Views-Controllers-XIB/LGConfigurationWindowController.m
+++ b/AutoPkgr/Views-Controllers-XIB/LGConfigurationWindowController.m
@@ -37,20 +37,28 @@
 
 - (instancetype)init
 {
+    LGLaunchProfileLog(@"configuration window init start");
     if (self = [super initWithWindowNibName:NSStringFromClass([self class])]) {
 
         _installView = [[LGInstallViewController alloc] initWithProgressDelegate:self];
+        LGLaunchProfileLog(@"install tab controller initialized");
         _scheduleView = [[LGScheduleViewController alloc] initWithProgressDelegate:self];
+        LGLaunchProfileLog(@"schedule tab controller initialized");
         _recipeRepoView = [[LGRecipeReposViewController alloc] initWithProgressDelegate:self];
+        LGLaunchProfileLog(@"recipes/repos tab controller initialized");
         _notificationView = [[LGNotificationsViewController alloc] initWithProgressDelegate:self];
+        LGLaunchProfileLog(@"notifications tab controller initialized");
         _integrationsView = [[LGIntegrationsViewController alloc] initWithProgressDelegate:self];
+        LGLaunchProfileLog(@"integrations tab controller initialized");
 
         // The integrationManager is required for the following views.
         _integrationManager = [[LGIntegrationManager alloc] init];
+        LGLaunchProfileLog(@"integration manager initialized");
 
         _installView.integrationManager = _integrationManager;
         _integrationsView.integrationManager = _integrationManager;
     }
+    LGLaunchProfileLog(@"configuration window init end");
     return self;
 }
 
@@ -67,11 +75,13 @@
 - (void)windowDidLoad
 {
     [super windowDidLoad];
+    LGLaunchProfileLog(@"configuration windowDidLoad");
 }
 
 - (void)awakeFromNib
 {
     if (!_awake) {
+        LGLaunchProfileLog(@"configuration window awakeFromNib start");
         // awakeFromNib can get called multiple times, but happens early.
         // Add code here that you want executed prior to the window showing.
         _awake = YES;
@@ -95,6 +105,7 @@
             tabItem.label = viewController.tabLabel;
             tabItem.view = viewController.view;
             [_tabViews addTabViewItem:tabItem];
+            LGLaunchProfileLog(@"configuration tab loaded: %@", tabItem.label);
         }
 
         // Make any modifications needed for specific integrations.
@@ -105,6 +116,7 @@
         _integrationsView.modalWindow = self.window;
         _recipeRepoView.modalWindow = self.window;
         _notificationView.modalWindow = self.window;
+        LGLaunchProfileLog(@"configuration window awakeFromNib end");
     }
 }
 

--- a/AutoPkgr/Views-Controllers-XIB/Recipes & Repos Table Controllers/LGRecipeTableViewController.m
+++ b/AutoPkgr/Views-Controllers-XIB/Recipes & Repos Table Controllers/LGRecipeTableViewController.m
@@ -22,6 +22,7 @@
 #import "LGAutoPkgRecipeListManager.h"
 #import "LGAutoPkgReport.h"
 #import "LGAutoPkgTask.h"
+#import "LGAutoPkgIntegration.h"
 #import "LGAutoPkgr.h"
 #import "LGRecipeInfoView.h"
 #import "LGRecipeOverrides.h"
@@ -45,6 +46,7 @@
     NSMutableDictionary *_runTaskDictionary;
     NSString *_currentRunningRecipe;
     BOOL _isAwake;
+    BOOL _autoPkgWasInstalled;
 }
 
 static NSString *const kLGAutoPkgRecipeIsEnabledKey = @"isEnabled";
@@ -53,10 +55,12 @@ static NSString *const kLGAutoPkgRecipeCurrentStatusKey = @"currentStatus";
 - (void)awakeFromNib
 {
     if (!_isAwake) {
+        LGLaunchProfileLog(@"recipe table awakeFromNib start");
         _isAwake = YES;
 
         [_recipeSearchField setTarget:self];
         [_recipeSearchField setAction:@selector(executeAppSearch:)];
+        _autoPkgWasInstalled = [LGAutoPkgIntegration isInstalled];
 
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didCreateOverride:) name:kLGNotificationOverrideCreated object:nil];
 
@@ -64,10 +68,15 @@ static NSString *const kLGAutoPkgRecipeCurrentStatusKey = @"currentStatus";
 
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reload) name:kLGNotificationReposModified object:nil];
 
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didUpdateIntegrationStatus:) name:kLGNotificationIntegrationStatusDidChange object:nil];
+
+        LGLaunchProfileLog(@"recipe table initial recipe load start");
         _searchedRecipes = self.recipes;
+        LGLaunchProfileLog(@"recipe table initial recipe load complete count=%lu", (unsigned long)_searchedRecipes.count);
 
         _recipeList = [[LGAutoPkgRecipeListManager alloc] init];
         [self refreshRecipeList];
+        LGLaunchProfileLog(@"recipe table awakeFromNib end");
     }
 }
 
@@ -255,8 +264,11 @@ static NSString *const kLGAutoPkgRecipeCurrentStatusKey = @"currentStatus";
 - (NSMutableArray *)recipes
 {
     if (!_recipes) {
+        LGLaunchProfileLog(@"LGAutoPkgRecipe allRecipes start");
         _recipes = [[LGAutoPkgRecipe allRecipes] mutableCopy];
+        LGLaunchProfileLog(@"LGAutoPkgRecipe allRecipes complete count=%lu", (unsigned long)_recipes.count);
         [_recipes sortUsingDescriptors:_recipeTableView.sortDescriptors];
+        LGLaunchProfileLog(@"recipe table sort complete");
     }
 
     return _recipes;
@@ -487,6 +499,25 @@ static NSString *const kLGAutoPkgRecipeCurrentStatusKey = @"currentStatus";
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{
         [self reload];
     }];
+}
+
+- (void)didUpdateIntegrationStatus:(NSNotification *)aNotification
+{
+    if (![aNotification.object isKindOfClass:[LGAutoPkgIntegration class]]) {
+        return;
+    }
+
+    // Re-scan only on the not-installed -> installed transition. YAML recipe
+    // parsing shells out to /usr/local/autopkg/python, which is exactly what
+    // +[LGAutoPkgIntegration isInstalled] checks for, so any YAML recipes found
+    // before AutoPkg was installed were silently skipped. Reloading here picks
+    // them up. The reverse transition is ignored: already-listed recipes don't
+    // need to be re-read just because AutoPkg was removed.
+    BOOL autoPkgIsInstalled = [LGAutoPkgIntegration isInstalled];
+    if (!_autoPkgWasInstalled && autoPkgIsInstalled) {
+        [self reload];
+    }
+    _autoPkgWasInstalled = autoPkgIsInstalled;
 }
 
 @end

--- a/AutoPkgrTests/AutoPkgrTests.m
+++ b/AutoPkgrTests/AutoPkgrTests.m
@@ -26,6 +26,7 @@
 #import <XCTest/XCTest.h>
 
 #import "LGAutoPkgErrorHandler.h"
+#import "LGAutoPkgRecipe.h"
 #import "LGAutoPkgRecipeListManager.h"
 #import "LGAutoPkgReport.h"
 #import "LGAutoPkgTask.h"
@@ -48,6 +49,11 @@ extern NSData *LGBuildSmtpMessage(NSString *subject, NSString *htmlBody,
                                   NSString *fromAddress, NSArray<NSString *> *toAddresses);
 
 static const BOOL _TEST_PRIVILEGED_HELPER = YES;
+
+@interface LGAutoPkgRecipe (AutoPkgrTests)
++ (NSDictionary *)dictionaryFromRecipeURL:(NSURL *)recipeURL;
++ (NSArray *)findRecipesRecursivelyAtPath:(NSString *)path isOverride:(BOOL)isOverride activeRecipes:(NSSet *)activeRecipes;
+@end
 
 @interface AutoPkgrTests : XCTestCase <LGProgressDelegate>
 
@@ -89,6 +95,21 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
     return tmpDir;
 }
 
+- (BOOL)autoPkgPythonIsAvailable
+{
+    return [[NSFileManager defaultManager] isExecutableFileAtPath:@"/usr/local/autopkg/python"];
+}
+
+- (NSString *)writeRecipeNamed:(NSString *)name contents:(NSString *)contents inDirectory:(NSString *)directory
+{
+    NSString *path = [directory stringByAppendingPathComponent:name];
+    NSError *error = nil;
+    BOOL success = [contents writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:&error];
+    XCTAssertTrue(success);
+    XCTAssertNil(error);
+    return path;
+}
+
 #pragma mark - LGAutoPkgTask
 - (void)testSyncMethods
 {
@@ -116,6 +137,191 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
     NSLog(@"%@", listManager.recipeLists);
 
     [listManager removeRecipeList:newList error:nil];
+}
+
+#pragma mark - LGAutoPkgRecipe
+- (void)testYAMLRecipeParsingMatchesAutoPkgMetadataSemantics
+{
+    if (![self autoPkgPythonIsAvailable]) {
+        return;
+    }
+
+    NSString *tmpDir = [self createTempDirectory];
+    NSString *path = [self writeRecipeNamed:@"Floaty.download.recipe.yaml"
+                                   contents:@"Identifier: com.example.floaty\n"
+                                            "MinimumVersion: 2.3\n"
+                                            "ParentRecipe:\n"
+                                            "Input:\n"
+                                            "  VERSION: 1.0\n"
+                                            "  NULL_LIST:\n"
+                                            "    -\n"
+                                            "  pkginfo:\n"
+                                            "    catalogs:\n"
+                                            "      - testing:\n"
+                                            "Process:\n"
+                                            "  - Processor: EndOfCheckPhase\n"
+                                inDirectory:tmpDir];
+
+    LGAutoPkgRecipe *recipe = [[LGAutoPkgRecipe alloc] initWithRecipeFile:[NSURL fileURLWithPath:path] isOverride:NO];
+    XCTAssertNotNil(recipe);
+    XCTAssertEqualObjects(recipe.Identifier, @"com.example.floaty");
+    XCTAssertEqualObjects(recipe.Name, @"Floaty.download");
+    XCTAssertEqualObjects(recipe.MinimumVersion, @"2.3");
+    XCTAssertNil(recipe.ParentRecipe);
+    XCTAssertFalse(recipe.isMissingParent);
+    XCTAssertEqualObjects(recipe.Input[@"VERSION"], @"1.0");
+    XCTAssertEqualObjects([recipe.Input[@"NULL_LIST"] firstObject], @"");
+
+    NSDictionary *pkginfo = recipe.Input[@"pkginfo"];
+    NSArray *catalogs = pkginfo[@"catalogs"];
+    NSDictionary *testingCatalog = catalogs.firstObject;
+    XCTAssertEqualObjects(testingCatalog[@"testing"], @"");
+}
+
+- (void)testYAMLRecipeInitializesWithLegacyInputIdentifier
+{
+    if (![self autoPkgPythonIsAvailable]) {
+        return;
+    }
+
+    NSString *tmpDir = [self createTempDirectory];
+    NSString *path = [self writeRecipeNamed:@"Legacy.recipe.yaml"
+                                   contents:@"Input:\n"
+                                            "  IDENTIFIER: com.example.legacy\n"
+                                            "  NAME: Legacy\n"
+                                            "Process: []\n"
+                                inDirectory:tmpDir];
+
+    LGAutoPkgRecipe *recipe = [[LGAutoPkgRecipe alloc] initWithRecipeFile:[NSURL fileURLWithPath:path] isOverride:NO];
+    XCTAssertNotNil(recipe);
+    XCTAssertEqualObjects(recipe.Identifier, @"com.example.legacy");
+}
+
+- (void)testInvalidYAMLRecipesDoNotInitialize
+{
+    if (![self autoPkgPythonIsAvailable]) {
+        return;
+    }
+
+    NSString *tmpDir = [self createTempDirectory];
+    NSString *malformedPath = [self writeRecipeNamed:@"Malformed.recipe.yaml"
+                                            contents:@"Identifier: [\n"
+                                         inDirectory:tmpDir];
+    NSString *listPath = [self writeRecipeNamed:@"List.recipe.yaml"
+                                       contents:@"- Identifier: com.example.list\n"
+                                    inDirectory:tmpDir];
+    NSString *nullIdentifierPath = [self writeRecipeNamed:@"NullIdentifier.recipe.yaml"
+                                                 contents:@"Identifier:\n"
+                                                          "Process: []\n"
+                                              inDirectory:tmpDir];
+
+    XCTAssertNil([[LGAutoPkgRecipe alloc] initWithRecipeFile:[NSURL fileURLWithPath:malformedPath] isOverride:NO]);
+    XCTAssertNil([[LGAutoPkgRecipe alloc] initWithRecipeFile:[NSURL fileURLWithPath:listPath] isOverride:NO]);
+    XCTAssertNil([[LGAutoPkgRecipe alloc] initWithRecipeFile:[NSURL fileURLWithPath:nullIdentifierPath] isOverride:NO]);
+}
+
+- (void)testRecipeNameStripsCanonicalRecipeExtensions
+{
+    NSString *tmpDir = [self createTempDirectory];
+    NSString *plistPath = [[tmpDir stringByAppendingPathComponent:@"Plisty.install.recipe"] stringByAppendingPathExtension:@"plist"];
+    NSDictionary *plistRecipe = @{ @"Identifier" : @"com.example.plisty" };
+    XCTAssertTrue([plistRecipe writeToFile:plistPath atomically:YES]);
+
+    LGAutoPkgRecipe *recipe = [[LGAutoPkgRecipe alloc] initWithRecipeFile:[NSURL fileURLWithPath:plistPath] isOverride:NO];
+    XCTAssertNotNil(recipe);
+    XCTAssertEqualObjects(recipe.Name, @"Plisty.install");
+}
+
+- (void)testRecipeDiscoveryUsesCanonicalYAMLRecipeExtension
+{
+    if (![self autoPkgPythonIsAvailable]) {
+        return;
+    }
+
+    NSString *tmpDir = [self createTempDirectory];
+    [self writeRecipeNamed:@"Valid.recipe.yaml"
+                  contents:@"Identifier: com.example.valid\nProcess: []\n"
+               inDirectory:tmpDir];
+    NSString *ignoredPath = [self writeRecipeNamed:@"Ignored.yaml"
+                                          contents:@"Identifier: com.example.ignored\nProcess: []\n"
+                                       inDirectory:tmpDir];
+
+    NSArray *recipes = [LGAutoPkgRecipe findRecipesRecursivelyAtPath:tmpDir isOverride:NO activeRecipes:nil];
+    NSArray *identifiers = [recipes valueForKey:@"Identifier"];
+    XCTAssertTrue([identifiers containsObject:@"com.example.valid"]);
+    XCTAssertFalse([identifiers containsObject:@"com.example.ignored"]);
+    XCTAssertNil([[LGAutoPkgRecipe alloc] initWithRecipeFile:[NSURL fileURLWithPath:ignoredPath] isOverride:NO]);
+}
+
+- (void)testBatchYAMLDiscoveryIsolatesInvalidRecipes
+{
+    if (![self autoPkgPythonIsAvailable]) {
+        return;
+    }
+
+    NSString *tmpDir = [self createTempDirectory];
+    [self writeRecipeNamed:@"Valid.recipe.yaml"
+                  contents:@"Identifier: com.example.batch.valid\nProcess: []\n"
+               inDirectory:tmpDir];
+    [self writeRecipeNamed:@"Malformed.recipe.yaml"
+                  contents:@"Identifier: [\n"
+               inDirectory:tmpDir];
+
+    NSArray *recipes = [LGAutoPkgRecipe findRecipesRecursivelyAtPath:tmpDir isOverride:NO activeRecipes:nil];
+    NSArray *identifiers = [recipes valueForKey:@"Identifier"];
+    XCTAssertTrue([identifiers containsObject:@"com.example.batch.valid"]);
+}
+
+- (void)testYAMLParentLookupWorksThroughDiscovery
+{
+    if (![self autoPkgPythonIsAvailable]) {
+        return;
+    }
+
+    NSString *tmpDir = [self createTempDirectory];
+    [self writeRecipeNamed:@"Parent.recipe.yaml"
+                  contents:@"Identifier: com.example.parent\n"
+                           "ParentRecipe:\n"
+                           "Process: []\n"
+               inDirectory:tmpDir];
+    [self writeRecipeNamed:@"Child.recipe.yaml"
+                  contents:@"Identifier: com.example.child\n"
+                           "ParentRecipe: com.example.parent\n"
+                           "Process: []\n"
+               inDirectory:tmpDir];
+
+    NSArray *recipes = [LGAutoPkgRecipe findRecipesRecursivelyAtPath:tmpDir isOverride:NO activeRecipes:nil];
+    NSPredicate *childPredicate = [NSPredicate predicateWithFormat:@"Identifier == %@", @"com.example.child"];
+    LGAutoPkgRecipe *child = [[recipes filteredArrayUsingPredicate:childPredicate] firstObject];
+    XCTAssertNotNil(child);
+    XCTAssertEqualObjects(child.ParentRecipes, (@[ @"com.example.parent" ]));
+}
+
+- (void)testYAMLRecipeCacheMissesWhenFileMetadataChanges
+{
+    if (![self autoPkgPythonIsAvailable]) {
+        return;
+    }
+
+    NSString *tmpDir = [self createTempDirectory];
+    NSString *path = [self writeRecipeNamed:@"Cached.recipe.yaml"
+                                   contents:@"Identifier: com.example.cache\nProcess: []\n"
+                                inDirectory:tmpDir];
+    NSURL *url = [NSURL fileURLWithPath:path];
+
+    NSDictionary *firstRead = [LGAutoPkgRecipe dictionaryFromRecipeURL:url];
+    XCTAssertEqualObjects(firstRead[@"Identifier"], @"com.example.cache");
+
+    NSError *error = nil;
+    NSString *updatedContents = @"Identifier: com.example.cache.updated\n"
+                                "Description: Updated cache fixture\n"
+                                "Process: []\n";
+    BOOL success = [updatedContents writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:&error];
+    XCTAssertTrue(success);
+    XCTAssertNil(error);
+
+    NSDictionary *secondRead = [LGAutoPkgRecipe dictionaryFromRecipeURL:url];
+    XCTAssertEqualObjects(secondRead[@"Identifier"], @"com.example.cache.updated");
 }
 
 #pragma mark - LGIntegrations

--- a/AutoPkgrTests/AutoPkgrTests.m
+++ b/AutoPkgrTests/AutoPkgrTests.m
@@ -178,6 +178,30 @@ static const BOOL _TEST_PRIVILEGED_HELPER = YES;
     XCTAssertEqualObjects(testingCatalog[@"testing"], @"");
 }
 
+- (void)testYAMLNumericScalarsCoerceToStringsForStringAccessors
+{
+    if (![self autoPkgPythonIsAvailable]) {
+        return;
+    }
+
+    // AutoPkg's YAML loader strips the float resolver, so `2.3` stays a string,
+    // but an integer scalar still parses as an NSNumber. The Description and
+    // MinimumVersion accessors are declared NSString * and feed
+    // NSTextField.safe_stringValue (which sends -length), so they must coerce.
+    NSString *tmpDir = [self createTempDirectory];
+    NSString *path = [self writeRecipeNamed:@"Numbery.download.recipe.yaml"
+                                   contents:@"Identifier: com.example.numbery\n"
+                                            "Description: 3\n"
+                                            "MinimumVersion: 3\n"
+                                            "Process: []\n"
+                                inDirectory:tmpDir];
+
+    LGAutoPkgRecipe *recipe = [[LGAutoPkgRecipe alloc] initWithRecipeFile:[NSURL fileURLWithPath:path] isOverride:NO];
+    XCTAssertNotNil(recipe);
+    XCTAssertEqualObjects(recipe.MinimumVersion, @"3");
+    XCTAssertEqualObjects(recipe.Description, @"3");
+}
+
 - (void)testYAMLRecipeInitializesWithLegacyInputIdentifier
 {
     if (![self autoPkgPythonIsAvailable]) {


### PR DESCRIPTION
AutoPkg has supported YAML recipes and overrides since [version 2.3](https://github.com/autopkg/autopkg/releases/tag/v2.3), but AutoPkgr hasn't been able to understand YAML so they haven't appeared in AutoPkgr's interface. This PR teaches AutoPkgr to read and display them. It only touches reading; override creation, repo management, and AutoPkg execution are all left alone.

The core change is a new `dictionaryFromRecipeURL:` helper that all recipe reads now go through. My idea is to shell out to AutoPkg's bundled `/usr/local/autopkg/python`, which emits an XML plist on stdout that we parse with `NSPropertyListSerialization`. Anything that goes wrong — unreadable file, malformed YAML, a non-dictionary root, missing Python, a non-zero exit — just returns `nil`, which preserves the existing behavior.

Reusing AutoPkg's own Python is probably the least invasive option here. The runtime is already a hard dependency, and it ships PyYAML plus AutoPkg's `AutoPkgYAMLLoader`. The inline script uses that loader (with a SafeLoader fallback that strips the float implicit resolver) so float-looking scalars like `MinimumVersion: 2.3` and `MAJOR_VERSION: 2.0` load as strings, matching plist behavior. It also mirrors AutoPkg's plist-safe serializer, converting `None` values to empty strings.

A few smaller details worth calling out:

- Discovery matches the canonical `*.recipe.yaml` suffix rather than a generic `*.yaml` or `*.yml`, so stray YAML files aren't mistaken for recipes.
- Display names strip the full recipe suffix, so `Foo.pkg.recipe.yaml` and `Foo.pkg.recipe` both show up as `Foo.pkg`.
- To keep parsing cheap, YAML reads are batched into a single Python invocation per scan (paths go in over stdin to dodge argv length limits) and cached in memory keyed by path, modification date, and size. The cache resets at the start of a full scan, so parent-chain walks and inherited-value getters reuse parsed dictionaries while changed files miss the stale entry; invalid recipes aren't cached.
- Per-file exception handling in the batch parser means one bad YAML recipe won't block its valid neighbors from loading.

There's also some opt-in launch-profiling instrumentation (`LGLaunchProfileLog`, gated on the existing `debug` preference setting) to measure scan/launch timing, since YAML parsing now happens during the startup recipe scan. New tests cover plist/YAML parsing, scalar typing, null handling, discovery filtering, parent lookup, and cache invalidation — the YAML tests no-op when AutoPkg's Python isn't installed.

No new parser dependencies (no Swift, Yams, libyaml, or CocoaPods), and no changes to override creation, repo management, or the privileged helper.

This deserves some pretty strenuous testing before releasing. I've added unit tests to cover much of the YAML parsing but I haven't done integration testing beyond the basics yet.

Resolves #672 #701 #667